### PR TITLE
refactor: remove mode detection, let action handle it

### DIFF
--- a/.github/workflows/agent.yaml
+++ b/.github/workflows/agent.yaml
@@ -73,19 +73,6 @@ jobs:
         # yamllint disable-line rule:line-length rule:comments
         uses: astral-sh/ruff-action@57714a7c8a2e59f32539362ba31877a1957dded1  # v3.5.1
 
-      - name: Determine mode
-        id: mode
-        shell: bash
-        run: |
-          EVENT="${{ github.event_name }}"
-          if [[ "$EVENT" == "pull_request" ]] || \
-             [[ "$EVENT" == "pull_request_review" ]] || \
-             [[ "$EVENT" == "pull_request_review_comment" ]]; then
-            echo "value=review" >> "$GITHUB_OUTPUT"
-          else
-            echo "value=agent" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Run Agent
         uses: dobbyphus/action@main
         with:
@@ -115,4 +102,3 @@ jobs:
               }
             }
           github_token: ${{ steps.app-token.outputs.token }}
-          mode: ${{ steps.mode.outputs.value }}


### PR DESCRIPTION
The dobbyphus/action now auto-detects mode based on comment content:
- @bot_name + 'review' anywhere in comment → review mode
- pull_request event (reviewer assigned) → review mode
- Everything else → agent mode