### PR TITLE
fix: use 3-way ref fallback for PR review comment events

### DIFF
--- a/.github/workflows/agent.yaml
+++ b/.github/workflows/agent.yaml
@@ -61,7 +61,11 @@ jobs:
         # yamllint disable-line rule:line-length rule:comments
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
         with:
-          ref: ${{ github.head_ref || github.ref }}
+          # github.head_ref: PR events (pull_request, pull_request_target)
+          # github.event.pull_request.head.ref: PR review/comment events
+          # github.ref: fallback for other events
+          # yamllint disable-line rule:line-length
+          ref: ${{ github.head_ref || github.event.pull_request.head.ref || github.ref }}
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
 


### PR DESCRIPTION
github.head_ref is empty for pull_request_review_comment events, causing checkout to use refs/pull/N/merge (detached HEAD).

Add github.event.pull_request.head.ref as middle fallback to correctly checkout the actual PR branch.