### PR TITLE
feat: disable progress bars by default for cleaner logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Config uses layered TOML with hot-reload:
 | `HF_HOME` | No | Hugging Face cache directory |
 | `CIVITAI_API_KEY` | No | Civitai API key for downloading restricted models |
 | `CIVITAI_CACHE_DIR` | No | Civitai cache directory (default: `~/.cache/civitai`) |
+| `ENABLE_PROGRESS_BARS` | No | Set to `1` to enable tqdm progress bars (disabled by default) |
 
 ## Discord Commands
 

--- a/src/oneiro/main.py
+++ b/src/oneiro/main.py
@@ -7,6 +7,13 @@ from oneiro.bot import create_bot
 
 def main() -> None:
     """Run the Oneiro Discord bot."""
+    if os.environ.get("ENABLE_PROGRESS_BARS", "").lower() not in ("1", "true", "yes", "on"):
+        os.environ.setdefault("HF_HUB_DISABLE_PROGRESS_BARS", "1")
+
+        from diffusers.utils import logging as diffusers_logging
+
+        diffusers_logging.disable_progress_bar()
+
     token = os.environ.get("TOKEN")
     if not token:
         raise ValueError("TOKEN environment variable required")


### PR DESCRIPTION
Progress bars are disabled unless ENABLE_PROGRESS_BARS=1 is set. Useful for headless/container environments where tqdm output is noise.