### PR TITLE
feat(device): centralize device management with DevicePolicy class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,6 @@ Thumbs.db
 
 # uv
 uv.lock
+
+.beads
+.gitattributes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,8 +6,8 @@ Discord bot for image generation with Huggingface Diffusers.
 
 ```bash
 uv pip install -e ".[dev]"           # Install dev dependencies
-uv run --extra dev pytest -v         # Run all tests
-uv run --extra dev pytest tests/test_config.py -v  # Single file
+uv run --extra dev pytest            # Run all tests
+uv run --extra dev pytest tests/test_config.py   # Single file
 ruff check src/ --fix                # Lint + auto-fix
 ruff format src/                     # Format
 ```
@@ -136,4 +136,21 @@ select = ["E", "W", "F", "I", "B", "C4", "UP"]
 
 [tool.ruff.lint.isort]
 known-first-party = ["oneiro"]
+```
+
+## Git Workflow
+
+- **Commits allowed** on atomic work units (single logical change)
+- **Never push** - leave pushing to the user
+- **Never `git add .`** - only stage specific files needed for the commit
+
+```bash
+# CORRECT: Stage specific files
+git add src/oneiro/config.py tests/test_config.py
+git commit -m "Add config hot reload support"
+
+# WRONG: Never do this
+git add .
+git add -A
+git push
 ```

--- a/src/oneiro/device.py
+++ b/src/oneiro/device.py
@@ -1,0 +1,93 @@
+"""Device management for pipeline placement."""
+
+from dataclasses import dataclass
+from enum import Enum
+
+import torch
+
+
+class OffloadMode(str, Enum):
+    """CPU offload behavior for CUDA pipelines."""
+
+    AUTO = "auto"  # Offload if CUDA available (default)
+    ALWAYS = "always"  # Require offload (error if not CUDA)
+    NEVER = "never"  # Never offload, use .to(device)
+
+
+@dataclass(frozen=True)
+class DevicePolicy:
+    """Immutable device configuration for pipeline placement.
+
+    Attributes:
+        device: Target device ("cuda", "mps", "cpu")
+        dtype: Torch dtype for model weights
+        offload: CPU offload behavior for large models
+    """
+
+    device: str
+    dtype: torch.dtype
+    offload: OffloadMode = OffloadMode.AUTO
+
+    @classmethod
+    def auto_detect(cls, cpu_offload: bool = True) -> "DevicePolicy":
+        """Create policy with auto-detected device and dtype.
+
+        Args:
+            cpu_offload: Enable CPU offloading when available (default: True)
+
+        Returns:
+            DevicePolicy configured for the best available device
+        """
+        if torch.cuda.is_available():
+            device = "cuda"
+            # Use bfloat16 only if supported, else float16
+            if torch.cuda.is_bf16_supported():
+                dtype = torch.bfloat16
+            else:
+                dtype = torch.float16
+        elif hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
+            device = "mps"
+            dtype = torch.float32  # MPS works best with float32
+        else:
+            device = "cpu"
+            dtype = torch.float32
+
+        offload = OffloadMode.AUTO if cpu_offload else OffloadMode.NEVER
+        return cls(device=device, dtype=dtype, offload=offload)
+
+    def apply_to_pipeline(self, pipe) -> None:
+        """Apply device policy to a diffusers pipeline.
+
+        Args:
+            pipe: A diffusers pipeline instance
+
+        Raises:
+            ValueError: If offload=ALWAYS but device is not CUDA
+        """
+        should_offload = self.offload == OffloadMode.ALWAYS or (
+            self.offload == OffloadMode.AUTO and self.device == "cuda"
+        )
+
+        if should_offload:
+            if self.device != "cuda":
+                raise ValueError(
+                    f"CPU offload requires CUDA device, got '{self.device}'. "
+                    f"Set cpu_offload=false in config or use a CUDA-enabled system."
+                )
+            pipe.enable_model_cpu_offload()
+        elif self.device != "cpu":
+            pipe.to(self.device)
+        # CPU: no action needed, pipeline stays on CPU
+
+    @staticmethod
+    def clear_cache() -> None:
+        """Clear device memory cache if applicable."""
+        if torch.cuda.is_available():
+            torch.cuda.synchronize()
+            torch.cuda.empty_cache()
+        elif (
+            hasattr(torch.backends, "mps")
+            and torch.backends.mps.is_available()
+            and hasattr(torch.mps, "empty_cache")
+        ):
+            torch.mps.empty_cache()

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1,0 +1,212 @@
+"""Tests for DevicePolicy."""
+
+import pytest
+import torch
+
+from oneiro.device import DevicePolicy, OffloadMode
+
+
+class TestOffloadMode:
+    """Tests for OffloadMode enum."""
+
+    def test_string_values(self):
+        assert OffloadMode.AUTO.value == "auto"
+        assert OffloadMode.ALWAYS.value == "always"
+        assert OffloadMode.NEVER.value == "never"
+
+    def test_is_str_subclass(self):
+        """OffloadMode should be usable as a string."""
+        assert isinstance(OffloadMode.AUTO, str)
+        assert OffloadMode.AUTO == "auto"
+
+
+class TestDevicePolicyAutoDetect:
+    """Tests for DevicePolicy.auto_detect()."""
+
+    def test_returns_device_policy(self):
+        policy = DevicePolicy.auto_detect()
+        assert isinstance(policy, DevicePolicy)
+        assert policy.device in ("cuda", "mps", "cpu")
+
+    def test_cpu_offload_true_sets_auto(self):
+        policy = DevicePolicy.auto_detect(cpu_offload=True)
+        assert policy.offload == OffloadMode.AUTO
+
+    def test_cpu_offload_false_sets_never(self):
+        policy = DevicePolicy.auto_detect(cpu_offload=False)
+        assert policy.offload == OffloadMode.NEVER
+
+    def test_dtype_is_valid_torch_dtype(self):
+        policy = DevicePolicy.auto_detect()
+        assert policy.dtype in (torch.float16, torch.bfloat16, torch.float32)
+
+    def test_cpu_device_uses_float32(self):
+        """CPU device should always use float32."""
+        # We can't force CPU detection, but we can verify the logic
+        policy = DevicePolicy(device="cpu", dtype=torch.float32)
+        assert policy.dtype == torch.float32
+
+
+class TestDevicePolicyFrozen:
+    """Tests for DevicePolicy immutability."""
+
+    def test_cannot_modify_device(self):
+        policy = DevicePolicy.auto_detect()
+        with pytest.raises(AttributeError):
+            policy.device = "cpu"
+
+    def test_cannot_modify_dtype(self):
+        policy = DevicePolicy.auto_detect()
+        with pytest.raises(AttributeError):
+            policy.dtype = torch.float32
+
+    def test_cannot_modify_offload(self):
+        policy = DevicePolicy.auto_detect()
+        with pytest.raises(AttributeError):
+            policy.offload = OffloadMode.NEVER
+
+
+class TestDevicePolicyApply:
+    """Tests for DevicePolicy.apply_to_pipeline()."""
+
+    def test_always_offload_on_non_cuda_raises(self):
+        policy = DevicePolicy(device="cpu", dtype=torch.float32, offload=OffloadMode.ALWAYS)
+
+        class MockPipeline:
+            pass
+
+        with pytest.raises(ValueError, match="CPU offload requires CUDA"):
+            policy.apply_to_pipeline(MockPipeline())
+
+    def test_always_offload_on_mps_raises(self):
+        policy = DevicePolicy(device="mps", dtype=torch.float32, offload=OffloadMode.ALWAYS)
+
+        class MockPipeline:
+            pass
+
+        with pytest.raises(ValueError, match="CPU offload requires CUDA"):
+            policy.apply_to_pipeline(MockPipeline())
+
+    def test_never_offload_calls_to_device(self):
+        policy = DevicePolicy(device="cuda", dtype=torch.float16, offload=OffloadMode.NEVER)
+
+        class MockPipeline:
+            def __init__(self):
+                self.moved_to = None
+
+            def to(self, device):
+                self.moved_to = device
+
+        pipe = MockPipeline()
+        policy.apply_to_pipeline(pipe)
+        assert pipe.moved_to == "cuda"
+
+    def test_auto_offload_on_cuda_enables_offload(self):
+        policy = DevicePolicy(device="cuda", dtype=torch.float16, offload=OffloadMode.AUTO)
+
+        class MockPipeline:
+            def __init__(self):
+                self.offload_enabled = False
+
+            def enable_model_cpu_offload(self):
+                self.offload_enabled = True
+
+        pipe = MockPipeline()
+        policy.apply_to_pipeline(pipe)
+        assert pipe.offload_enabled is True
+
+    def test_auto_offload_on_cpu_no_action(self):
+        policy = DevicePolicy(device="cpu", dtype=torch.float32, offload=OffloadMode.AUTO)
+
+        class MockPipeline:
+            def __init__(self):
+                self.to_called = False
+                self.offload_called = False
+
+            def to(self, device):
+                self.to_called = True
+
+            def enable_model_cpu_offload(self):
+                self.offload_called = True
+
+        pipe = MockPipeline()
+        policy.apply_to_pipeline(pipe)
+        assert not pipe.to_called
+        assert not pipe.offload_called
+
+    def test_cpu_device_no_action(self):
+        policy = DevicePolicy(device="cpu", dtype=torch.float32, offload=OffloadMode.NEVER)
+
+        class MockPipeline:
+            def __init__(self):
+                self.to_called = False
+                self.offload_called = False
+
+            def to(self, device):
+                self.to_called = True
+
+            def enable_model_cpu_offload(self):
+                self.offload_called = True
+
+        pipe = MockPipeline()
+        policy.apply_to_pipeline(pipe)
+        assert not pipe.to_called
+        assert not pipe.offload_called
+
+    def test_mps_device_moves_to_mps(self):
+        policy = DevicePolicy(device="mps", dtype=torch.float32, offload=OffloadMode.NEVER)
+
+        class MockPipeline:
+            def __init__(self):
+                self.moved_to = None
+
+            def to(self, device):
+                self.moved_to = device
+
+        pipe = MockPipeline()
+        policy.apply_to_pipeline(pipe)
+        assert pipe.moved_to == "mps"
+
+
+class TestDevicePolicyClearCache:
+    """Tests for DevicePolicy.clear_cache()."""
+
+    def test_clear_cache_does_not_raise(self):
+        # Should not raise regardless of device availability
+        DevicePolicy.clear_cache()
+
+    def test_clear_cache_is_static(self):
+        # Can be called without an instance
+        DevicePolicy.clear_cache()
+
+
+class TestDevicePolicyEquality:
+    """Tests for DevicePolicy equality and hashing."""
+
+    def test_equal_policies(self):
+        p1 = DevicePolicy(device="cuda", dtype=torch.float16, offload=OffloadMode.AUTO)
+        p2 = DevicePolicy(device="cuda", dtype=torch.float16, offload=OffloadMode.AUTO)
+        assert p1 == p2
+
+    def test_unequal_device(self):
+        p1 = DevicePolicy(device="cuda", dtype=torch.float16, offload=OffloadMode.AUTO)
+        p2 = DevicePolicy(device="cpu", dtype=torch.float16, offload=OffloadMode.AUTO)
+        assert p1 != p2
+
+    def test_unequal_dtype(self):
+        p1 = DevicePolicy(device="cuda", dtype=torch.float16, offload=OffloadMode.AUTO)
+        p2 = DevicePolicy(device="cuda", dtype=torch.bfloat16, offload=OffloadMode.AUTO)
+        assert p1 != p2
+
+    def test_unequal_offload(self):
+        p1 = DevicePolicy(device="cuda", dtype=torch.float16, offload=OffloadMode.AUTO)
+        p2 = DevicePolicy(device="cuda", dtype=torch.float16, offload=OffloadMode.NEVER)
+        assert p1 != p2
+
+    def test_hashable(self):
+        p = DevicePolicy(device="cuda", dtype=torch.float16, offload=OffloadMode.AUTO)
+        # Should not raise - frozen dataclasses are hashable
+        hash(p)
+        # Can be used in sets
+        s = {p}
+        assert p in s

--- a/tests/test_pipelines_flux1.py
+++ b/tests/test_pipelines_flux1.py
@@ -3,32 +3,32 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
+import torch
 from PIL import Image
 
+from oneiro.device import DevicePolicy, OffloadMode
 from oneiro.pipelines.flux1 import Flux1PipelineWrapper
 
 
 class TestFlux1PipelineWrapperInit:
     """Tests for Flux1PipelineWrapper initialization."""
 
-    @patch("oneiro.pipelines.base.torch.cuda.is_available", return_value=False)
-    def test_init_creates_instance(self, mock_cuda):
+    def test_init_creates_instance(self):
         """Flux1PipelineWrapper can be instantiated."""
-        pipeline = Flux1PipelineWrapper()
+        mock_policy = DevicePolicy(device="cpu", dtype=torch.float32, offload=OffloadMode.NEVER)
+        with patch.object(DevicePolicy, "auto_detect", return_value=mock_policy):
+            pipeline = Flux1PipelineWrapper()
         assert pipeline.pipe is None
-        assert pipeline._device == "cpu"
+        assert pipeline.policy.device == "cpu"
 
 
 class TestFlux1PipelineWrapperLoad:
     """Tests for Flux1PipelineWrapper.load()."""
 
-    @patch("oneiro.pipelines.base.torch.cuda.is_available", return_value=False)
     @patch("oneiro.pipelines.base.torch.set_num_interop_threads")
     @patch("oneiro.pipelines.base.torch.set_num_threads")
     @patch("diffusers.FluxPipeline")
-    def test_load_with_default_repo(
-        self, mock_flux_pipeline, mock_threads, mock_interop, mock_cuda
-    ):
+    def test_load_with_default_repo(self, mock_flux_pipeline, mock_threads, mock_interop):
         """Load uses default repo when not specified."""
         mock_pipe = MagicMock()
         mock_flux_pipeline.from_pretrained.return_value = mock_pipe
@@ -40,11 +40,10 @@ class TestFlux1PipelineWrapperLoad:
         call_args = mock_flux_pipeline.from_pretrained.call_args
         assert call_args[0][0] == "black-forest-labs/FLUX.1-dev"
 
-    @patch("oneiro.pipelines.base.torch.cuda.is_available", return_value=False)
     @patch("oneiro.pipelines.base.torch.set_num_interop_threads")
     @patch("oneiro.pipelines.base.torch.set_num_threads")
     @patch("diffusers.FluxPipeline")
-    def test_load_with_custom_repo(self, mock_flux_pipeline, mock_threads, mock_interop, mock_cuda):
+    def test_load_with_custom_repo(self, mock_flux_pipeline, mock_threads, mock_interop):
         """Load uses custom repo from config."""
         mock_pipe = MagicMock()
         mock_flux_pipeline.from_pretrained.return_value = mock_pipe
@@ -55,28 +54,27 @@ class TestFlux1PipelineWrapperLoad:
         call_args = mock_flux_pipeline.from_pretrained.call_args
         assert call_args[0][0] == "black-forest-labs/FLUX.1-schnell"
 
-    @patch("oneiro.pipelines.base.torch.cuda.is_available", return_value=False)
     @patch("oneiro.pipelines.base.torch.set_num_interop_threads")
     @patch("oneiro.pipelines.base.torch.set_num_threads")
     @patch("diffusers.FluxPipeline")
-    def test_load_enables_cpu_offload_by_default(
-        self, mock_flux_pipeline, mock_threads, mock_interop, mock_cuda
-    ):
-        """Load enables CPU offload by default."""
+    def test_load_enables_cpu_offload_on_cuda(self, mock_flux_pipeline, mock_threads, mock_interop):
+        """Load enables CPU offload on CUDA by default."""
         mock_pipe = MagicMock()
         mock_flux_pipeline.from_pretrained.return_value = mock_pipe
 
-        pipeline = Flux1PipelineWrapper()
-        pipeline.load({})
+        # Mock CUDA being available
+        mock_policy = DevicePolicy(device="cuda", dtype=torch.float16, offload=OffloadMode.AUTO)
+        with patch.object(DevicePolicy, "auto_detect", return_value=mock_policy):
+            pipeline = Flux1PipelineWrapper()
+            pipeline.load({})
 
         mock_pipe.enable_model_cpu_offload.assert_called_once()
 
-    @patch("oneiro.pipelines.base.torch.cuda.is_available", return_value=False)
     @patch("oneiro.pipelines.base.torch.set_num_interop_threads")
     @patch("oneiro.pipelines.base.torch.set_num_threads")
     @patch("diffusers.FluxPipeline")
     def test_load_disables_cpu_offload_when_configured(
-        self, mock_flux_pipeline, mock_threads, mock_interop, mock_cuda
+        self, mock_flux_pipeline, mock_threads, mock_interop
     ):
         """Load respects cpu_offload=False config."""
         mock_pipe = MagicMock()
@@ -87,13 +85,10 @@ class TestFlux1PipelineWrapperLoad:
 
         mock_pipe.enable_model_cpu_offload.assert_not_called()
 
-    @patch("oneiro.pipelines.base.torch.cuda.is_available", return_value=False)
     @patch("oneiro.pipelines.base.torch.set_num_interop_threads")
     @patch("oneiro.pipelines.base.torch.set_num_threads")
     @patch("diffusers.FluxPipeline")
-    def test_load_enables_vae_optimizations(
-        self, mock_flux_pipeline, mock_threads, mock_interop, mock_cuda
-    ):
+    def test_load_enables_vae_optimizations(self, mock_flux_pipeline, mock_threads, mock_interop):
         """Load enables VAE tiling and slicing for memory optimization."""
         mock_pipe = MagicMock()
         mock_flux_pipeline.from_pretrained.return_value = mock_pipe
@@ -104,11 +99,10 @@ class TestFlux1PipelineWrapperLoad:
         mock_pipe.vae.enable_tiling.assert_called_once()
         mock_pipe.vae.enable_slicing.assert_called_once()
 
-    @patch("oneiro.pipelines.base.torch.cuda.is_available", return_value=False)
     @patch("oneiro.pipelines.base.torch.set_num_interop_threads")
     @patch("oneiro.pipelines.base.torch.set_num_threads")
     @patch("diffusers.FluxPipeline")
-    def test_load_with_lora(self, mock_flux_pipeline, mock_threads, mock_interop, mock_cuda):
+    def test_load_with_lora(self, mock_flux_pipeline, mock_threads, mock_interop):
         """Load applies LoRA weights when lora and lora_weights are specified."""
         mock_pipe = MagicMock()
         mock_flux_pipeline.from_pretrained.return_value = mock_pipe
@@ -125,11 +119,10 @@ class TestFlux1PipelineWrapperLoad:
             "example/flux-lora-repo", weight_name="flux_lora.safetensors"
         )
 
-    @patch("oneiro.pipelines.base.torch.cuda.is_available", return_value=False)
     @patch("oneiro.pipelines.base.torch.set_num_interop_threads")
     @patch("oneiro.pipelines.base.torch.set_num_threads")
     @patch("diffusers.FluxPipeline")
-    def test_load_without_lora(self, mock_flux_pipeline, mock_threads, mock_interop, mock_cuda):
+    def test_load_without_lora(self, mock_flux_pipeline, mock_threads, mock_interop):
         """Load does not call load_lora_weights when lora config is not specified."""
         mock_pipe = MagicMock()
         mock_flux_pipeline.from_pretrained.return_value = mock_pipe
@@ -139,12 +132,11 @@ class TestFlux1PipelineWrapperLoad:
 
         mock_pipe.load_lora_weights.assert_not_called()
 
-    @patch("oneiro.pipelines.base.torch.cuda.is_available", return_value=False)
     @patch("oneiro.pipelines.base.torch.set_num_interop_threads")
     @patch("oneiro.pipelines.base.torch.set_num_threads")
     @patch("diffusers.FluxPipeline")
     def test_load_with_lora_repo_only_no_weights(
-        self, mock_flux_pipeline, mock_threads, mock_interop, mock_cuda
+        self, mock_flux_pipeline, mock_threads, mock_interop
     ):
         """Load does not call load_lora_weights when only lora repo is specified (no weights)."""
         mock_pipe = MagicMock()
@@ -159,145 +151,153 @@ class TestFlux1PipelineWrapperLoad:
 class TestFlux1PipelineWrapperGenerate:
     """Tests for Flux1PipelineWrapper.generate()."""
 
-    @patch("oneiro.pipelines.base.torch.cuda.is_available", return_value=False)
-    def test_generate_raises_when_not_loaded(self, mock_cuda):
+    def test_generate_raises_when_not_loaded(self):
         """Generate raises RuntimeError when pipeline not loaded."""
-        pipeline = Flux1PipelineWrapper()
-        with pytest.raises(RuntimeError, match="Pipeline not loaded"):
-            pipeline.generate("test prompt")
+        mock_policy = DevicePolicy(device="cpu", dtype=torch.float32, offload=OffloadMode.NEVER)
+        with patch.object(DevicePolicy, "auto_detect", return_value=mock_policy):
+            pipeline = Flux1PipelineWrapper()
+            with pytest.raises(RuntimeError, match="Pipeline not loaded"):
+                pipeline.generate("test prompt")
 
-    @patch("oneiro.pipelines.base.torch.cuda.is_available", return_value=False)
-    def test_generate_returns_result(self, mock_cuda):
+    def test_generate_returns_result(self):
         """Generate returns GenerationResult with correct fields."""
-        pipeline = Flux1PipelineWrapper()
-        mock_pipe = MagicMock()
-        mock_image = Image.new("RGB", (1024, 1024), color="blue")
-        mock_pipe.return_value.images = [mock_image]
-        pipeline.pipe = mock_pipe
+        mock_policy = DevicePolicy(device="cpu", dtype=torch.float32, offload=OffloadMode.NEVER)
+        with patch.object(DevicePolicy, "auto_detect", return_value=mock_policy):
+            pipeline = Flux1PipelineWrapper()
+            mock_pipe = MagicMock()
+            mock_image = Image.new("RGB", (1024, 1024), color="blue")
+            mock_pipe.return_value.images = [mock_image]
+            pipeline.pipe = mock_pipe
 
-        result = pipeline.generate("a beautiful landscape", seed=42)
+            result = pipeline.generate("a beautiful landscape", seed=42)
 
-        assert result.image is mock_image
-        assert result.seed == 42
-        assert result.prompt == "a beautiful landscape"
-        assert result.width == 1024
-        assert result.height == 1024
+            assert result.image is mock_image
+            assert result.seed == 42
+            assert result.prompt == "a beautiful landscape"
+            assert result.width == 1024
+            assert result.height == 1024
 
-    @patch("oneiro.pipelines.base.torch.cuda.is_available", return_value=False)
-    def test_generate_uses_default_parameters(self, mock_cuda):
+    def test_generate_uses_default_parameters(self):
         """Generate uses correct default parameters for FLUX.1-dev."""
-        pipeline = Flux1PipelineWrapper()
-        mock_pipe = MagicMock()
-        mock_image = Image.new("RGB", (1024, 1024))
-        mock_pipe.return_value.images = [mock_image]
-        pipeline.pipe = mock_pipe
+        mock_policy = DevicePolicy(device="cpu", dtype=torch.float32, offload=OffloadMode.NEVER)
+        with patch.object(DevicePolicy, "auto_detect", return_value=mock_policy):
+            pipeline = Flux1PipelineWrapper()
+            mock_pipe = MagicMock()
+            mock_image = Image.new("RGB", (1024, 1024))
+            mock_pipe.return_value.images = [mock_image]
+            pipeline.pipe = mock_pipe
 
-        pipeline.generate("test prompt", seed=42)
+            pipeline.generate("test prompt", seed=42)
 
-        call_kwargs = mock_pipe.call_args[1]
-        assert call_kwargs["num_inference_steps"] == 28
-        assert call_kwargs["guidance_scale"] == 3.5
-        assert call_kwargs["max_sequence_length"] == 512
+            call_kwargs = mock_pipe.call_args[1]
+            assert call_kwargs["num_inference_steps"] == 28
+            assert call_kwargs["guidance_scale"] == 3.5
+            assert call_kwargs["max_sequence_length"] == 512
 
-    @patch("oneiro.pipelines.base.torch.cuda.is_available", return_value=False)
-    def test_generate_with_custom_parameters(self, mock_cuda):
+    def test_generate_with_custom_parameters(self):
         """Generate respects custom parameters."""
-        pipeline = Flux1PipelineWrapper()
-        mock_pipe = MagicMock()
-        mock_image = Image.new("RGB", (512, 512))
-        mock_pipe.return_value.images = [mock_image]
-        pipeline.pipe = mock_pipe
+        mock_policy = DevicePolicy(device="cpu", dtype=torch.float32, offload=OffloadMode.NEVER)
+        with patch.object(DevicePolicy, "auto_detect", return_value=mock_policy):
+            pipeline = Flux1PipelineWrapper()
+            mock_pipe = MagicMock()
+            mock_image = Image.new("RGB", (512, 512))
+            mock_pipe.return_value.images = [mock_image]
+            pipeline.pipe = mock_pipe
 
-        result = pipeline.generate(
-            "test prompt",
-            width=512,
-            height=512,
-            seed=123,
-            steps=4,
-            guidance_scale=0.0,
-        )
+            result = pipeline.generate(
+                "test prompt",
+                width=512,
+                height=512,
+                seed=123,
+                steps=4,
+                guidance_scale=0.0,
+            )
 
-        call_kwargs = mock_pipe.call_args[1]
-        assert call_kwargs["width"] == 512
-        assert call_kwargs["height"] == 512
-        assert call_kwargs["num_inference_steps"] == 4
-        assert call_kwargs["guidance_scale"] == 0.0
-        assert result.steps == 4
+            call_kwargs = mock_pipe.call_args[1]
+            assert call_kwargs["width"] == 512
+            assert call_kwargs["height"] == 512
+            assert call_kwargs["num_inference_steps"] == 4
+            assert call_kwargs["guidance_scale"] == 0.0
+            assert result.steps == 4
 
-    @patch("oneiro.pipelines.base.torch.cuda.is_available", return_value=False)
-    def test_generate_accepts_negative_prompt_for_api_compatibility(self, mock_cuda):
+    def test_generate_accepts_negative_prompt_for_api_compatibility(self):
         """Generate accepts negative_prompt even though FLUX.1 doesn't use it."""
-        pipeline = Flux1PipelineWrapper()
-        mock_pipe = MagicMock()
-        mock_image = Image.new("RGB", (1024, 1024))
-        mock_pipe.return_value.images = [mock_image]
-        pipeline.pipe = mock_pipe
+        mock_policy = DevicePolicy(device="cpu", dtype=torch.float32, offload=OffloadMode.NEVER)
+        with patch.object(DevicePolicy, "auto_detect", return_value=mock_policy):
+            pipeline = Flux1PipelineWrapper()
+            mock_pipe = MagicMock()
+            mock_image = Image.new("RGB", (1024, 1024))
+            mock_pipe.return_value.images = [mock_image]
+            pipeline.pipe = mock_pipe
 
-        result = pipeline.generate("test prompt", negative_prompt="blurry", seed=42)
+            result = pipeline.generate("test prompt", negative_prompt="blurry", seed=42)
 
-        # negative_prompt is stored in result for compatibility
-        assert result.negative_prompt == "blurry"
+            # negative_prompt is stored in result for compatibility
+            assert result.negative_prompt == "blurry"
 
-    @patch("oneiro.pipelines.base.torch.cuda.is_available", return_value=False)
-    def test_generate_random_seed_when_negative(self, mock_cuda):
+    def test_generate_random_seed_when_negative(self):
         """Generate uses random seed when seed < 0."""
-        pipeline = Flux1PipelineWrapper()
-        mock_pipe = MagicMock()
-        mock_image = Image.new("RGB", (1024, 1024))
-        mock_pipe.return_value.images = [mock_image]
-        pipeline.pipe = mock_pipe
+        mock_policy = DevicePolicy(device="cpu", dtype=torch.float32, offload=OffloadMode.NEVER)
+        with patch.object(DevicePolicy, "auto_detect", return_value=mock_policy):
+            pipeline = Flux1PipelineWrapper()
+            mock_pipe = MagicMock()
+            mock_image = Image.new("RGB", (1024, 1024))
+            mock_pipe.return_value.images = [mock_image]
+            pipeline.pipe = mock_pipe
 
-        result = pipeline.generate("test prompt", seed=-1)
+            result = pipeline.generate("test prompt", seed=-1)
 
-        assert result.seed >= 0
-        assert result.seed < 2**32
+            assert result.seed >= 0
+            assert result.seed < 2**32
 
 
 class TestFlux1PipelineWrapperImg2Img:
     """Tests for Flux1PipelineWrapper img2img functionality."""
 
-    @patch("oneiro.pipelines.base.torch.cuda.is_available", return_value=False)
-    def test_generate_with_init_image(self, mock_cuda):
+    def test_generate_with_init_image(self):
         """Generate supports img2img with init_image."""
         import io
 
-        pipeline = Flux1PipelineWrapper()
-        mock_pipe = MagicMock()
-        mock_output = Image.new("RGB", (1024, 1024))
-        mock_pipe.return_value.images = [mock_output]
-        pipeline.pipe = mock_pipe
+        mock_policy = DevicePolicy(device="cpu", dtype=torch.float32, offload=OffloadMode.NEVER)
+        with patch.object(DevicePolicy, "auto_detect", return_value=mock_policy):
+            pipeline = Flux1PipelineWrapper()
+            mock_pipe = MagicMock()
+            mock_output = Image.new("RGB", (1024, 1024))
+            mock_pipe.return_value.images = [mock_output]
+            pipeline.pipe = mock_pipe
 
-        # Create init image bytes
-        init_img = Image.new("RGB", (512, 512), color="red")
-        buffer = io.BytesIO()
-        init_img.save(buffer, format="PNG")
-        init_bytes = buffer.getvalue()
+            # Create init image bytes
+            init_img = Image.new("RGB", (512, 512), color="red")
+            buffer = io.BytesIO()
+            init_img.save(buffer, format="PNG")
+            init_bytes = buffer.getvalue()
 
-        result = pipeline.generate("test prompt", seed=42, init_image=init_bytes)
+            result = pipeline.generate("test prompt", seed=42, init_image=init_bytes)
 
-        call_kwargs = mock_pipe.call_args[1]
-        assert "image" in call_kwargs
-        assert call_kwargs["strength"] == 0.75  # default strength
-        assert result.prompt == "test prompt"
+            call_kwargs = mock_pipe.call_args[1]
+            assert "image" in call_kwargs
+            assert call_kwargs["strength"] == 0.75  # default strength
+            assert result.prompt == "test prompt"
 
-    @patch("oneiro.pipelines.base.torch.cuda.is_available", return_value=False)
-    def test_generate_with_custom_strength(self, mock_cuda):
+    def test_generate_with_custom_strength(self):
         """Generate respects custom strength for img2img."""
         import io
 
-        pipeline = Flux1PipelineWrapper()
-        mock_pipe = MagicMock()
-        mock_output = Image.new("RGB", (1024, 1024))
-        mock_pipe.return_value.images = [mock_output]
-        pipeline.pipe = mock_pipe
+        mock_policy = DevicePolicy(device="cpu", dtype=torch.float32, offload=OffloadMode.NEVER)
+        with patch.object(DevicePolicy, "auto_detect", return_value=mock_policy):
+            pipeline = Flux1PipelineWrapper()
+            mock_pipe = MagicMock()
+            mock_output = Image.new("RGB", (1024, 1024))
+            mock_pipe.return_value.images = [mock_output]
+            pipeline.pipe = mock_pipe
 
-        # Create init image bytes
-        init_img = Image.new("RGB", (512, 512), color="red")
-        buffer = io.BytesIO()
-        init_img.save(buffer, format="PNG")
-        init_bytes = buffer.getvalue()
+            # Create init image bytes
+            init_img = Image.new("RGB", (512, 512), color="red")
+            buffer = io.BytesIO()
+            init_img.save(buffer, format="PNG")
+            init_bytes = buffer.getvalue()
 
-        pipeline.generate("test prompt", seed=42, init_image=init_bytes, strength=0.5)
+            pipeline.generate("test prompt", seed=42, init_image=init_bytes, strength=0.5)
 
-        call_kwargs = mock_pipe.call_args[1]
-        assert call_kwargs["strength"] == 0.5
+            call_kwargs = mock_pipe.call_args[1]
+            assert call_kwargs["strength"] == 0.5


### PR DESCRIPTION
- Add DevicePolicy frozen dataclass with auto_detect(), apply_to_pipeline(), clear_cache()
- Add OffloadMode enum (AUTO, ALWAYS, NEVER)
- Update BasePipeline to use policy instead of _device/_dtype
- Update all 5 pipeline implementations to use DevicePolicy
- Fix qwen.py LoRA loading order bug (device first, then LoRAs)
- Fix zimage.py to read cpu_offload from config
- Add MPS support with automatic float32
- Add comprehensive tests for DevicePolicy