### PR TITLE
refactor(civitai): extract parse_civitai_url

### DIFF
--- a/src/oneiro/bot.py
+++ b/src/oneiro/bot.py
@@ -9,7 +9,7 @@ from typing import Any
 import discord
 from discord import option
 
-from oneiro.civitai import CivitaiClient, CivitaiError
+from oneiro.civitai import CivitaiClient, CivitaiError, parse_civitai_url
 from oneiro.config import Config
 from oneiro.filters import ContentFilter
 from oneiro.lora_detector import AutoLoraDetector, create_detector_from_config
@@ -21,7 +21,7 @@ from oneiro.pipelines import (
     PipelineManager,
 )
 from oneiro.pipelines.civitai_checkpoint import CivitaiCheckpointPipeline
-from oneiro.pipelines.lora import is_lora_compatible, parse_civitai_url
+from oneiro.pipelines.lora import is_lora_compatible
 from oneiro.queue import GenerationQueue, QueueStatus
 
 # Global managers (initialized on bot ready)

--- a/src/oneiro/civitai.py
+++ b/src/oneiro/civitai.py
@@ -4,6 +4,7 @@ import asyncio
 import hashlib
 import json
 import os
+import re
 import shutil
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
@@ -61,6 +62,38 @@ class BaseModel(str, Enum):
     SDXL_1_0 = "SDXL 1.0"
     PONY = "Pony"
     FLUX_1 = "Flux.1"
+
+
+def parse_civitai_url(url: str) -> tuple[int, int | None]:
+    """Parse Civitai URL to extract model ID and optional version ID.
+
+    Supports formats:
+    - https://civitai.com/models/12345
+    - https://civitai.com/models/12345/model-name
+    - https://civitai.com/models/12345?modelVersionId=67890
+    - https://civitai.com/models/12345/name?modelVersionId=67890
+
+    Args:
+        url: Civitai model URL
+
+    Returns:
+        Tuple of (model_id, version_id or None)
+
+    Raises:
+        ValueError: If URL format is invalid
+    """
+    # Match model ID in path
+    model_match = re.search(r"/models/(\d+)", url)
+    if not model_match:
+        raise ValueError(f"Invalid Civitai URL format: {url}")
+
+    model_id = int(model_match.group(1))
+
+    # Check for version in query string
+    version_match = re.search(r"modelVersionId=(\d+)", url)
+    version_id = int(version_match.group(1)) if version_match else None
+
+    return model_id, version_id
 
 
 @dataclass

--- a/src/oneiro/pipelines/embedding.py
+++ b/src/oneiro/pipelines/embedding.py
@@ -1,12 +1,11 @@
 """Textual inversion / embedding configuration types and loading utilities."""
 
-import re
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
 from typing import Any
 
-from oneiro.civitai import CivitaiClient
+from oneiro.civitai import CivitaiClient, parse_civitai_url
 from oneiro.pipelines.lora import PIPELINE_BASE_MODEL_MAP
 
 
@@ -67,38 +66,6 @@ class EmbeddingConfig:
         elif self.source == EmbeddingSource.LOCAL:
             if not self.path:
                 raise ValueError("local source requires path")
-
-
-def parse_civitai_url(url: str) -> tuple[int, int | None]:
-    """Parse Civitai URL to extract model ID and optional version ID.
-
-    Supports formats:
-    - https://civitai.com/models/12345
-    - https://civitai.com/models/12345/model-name
-    - https://civitai.com/models/12345?modelVersionId=67890
-    - https://civitai.com/models/12345/name?modelVersionId=67890
-
-    Args:
-        url: Civitai model URL
-
-    Returns:
-        Tuple of (model_id, version_id or None)
-
-    Raises:
-        ValueError: If URL format is invalid
-    """
-    # Match model ID in path
-    model_match = re.search(r"/models/(\d+)", url)
-    if not model_match:
-        raise ValueError(f"Invalid Civitai URL format: {url}")
-
-    model_id = int(model_match.group(1))
-
-    # Check for version in query string
-    version_match = re.search(r"modelVersionId=(\d+)", url)
-    version_id = int(version_match.group(1)) if version_match else None
-
-    return model_id, version_id
 
 
 def parse_embedding_config(

--- a/src/oneiro/pipelines/lora.py
+++ b/src/oneiro/pipelines/lora.py
@@ -1,12 +1,11 @@
 """LoRA configuration types and loading utilities."""
 
-import re
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
 from typing import Any
 
-from oneiro.civitai import CivitaiClient
+from oneiro.civitai import CivitaiClient, parse_civitai_url
 
 
 class LoraSource(str, Enum):
@@ -78,38 +77,6 @@ class LoraConfig:
         elif self.source == LoraSource.LOCAL:
             if not self.path:
                 raise ValueError("local source requires path")
-
-
-def parse_civitai_url(url: str) -> tuple[int, int | None]:
-    """Parse Civitai URL to extract model ID and optional version ID.
-
-    Supports formats:
-    - https://civitai.com/models/12345
-    - https://civitai.com/models/12345/model-name
-    - https://civitai.com/models/12345?modelVersionId=67890
-    - https://civitai.com/models/12345/name?modelVersionId=67890
-
-    Args:
-        url: Civitai model URL
-
-    Returns:
-        Tuple of (model_id, version_id or None)
-
-    Raises:
-        ValueError: If URL format is invalid
-    """
-    # Match model ID in path
-    model_match = re.search(r"/models/(\d+)", url)
-    if not model_match:
-        raise ValueError(f"Invalid Civitai URL format: {url}")
-
-    model_id = int(model_match.group(1))
-
-    # Check for version in query string
-    version_match = re.search(r"modelVersionId=(\d+)", url)
-    version_id = int(version_match.group(1)) if version_match else None
-
-    return model_id, version_id
 
 
 def parse_lora_config(config: dict[str, Any] | str, index: int = 0) -> LoraConfig:

--- a/tests/test_civitai.py
+++ b/tests/test_civitai.py
@@ -17,7 +17,46 @@ from oneiro.civitai import (
     ModelFile,
     ModelType,
     ModelVersion,
+    parse_civitai_url,
 )
+
+
+class TestParseCivitaiUrl:
+    """Tests for parse_civitai_url function."""
+
+    def test_basic_model_url(self):
+        """Parses basic model URL."""
+        model_id, version_id = parse_civitai_url("https://civitai.com/models/12345")
+        assert model_id == 12345
+        assert version_id is None
+
+    def test_model_url_with_name(self):
+        """Parses model URL with name slug."""
+        model_id, version_id = parse_civitai_url("https://civitai.com/models/12345/my-cool-model")
+        assert model_id == 12345
+        assert version_id is None
+
+    def test_model_url_with_version(self):
+        """Parses model URL with version ID in query string."""
+        model_id, version_id = parse_civitai_url(
+            "https://civitai.com/models/12345?modelVersionId=67890"
+        )
+        assert model_id == 12345
+        assert version_id == 67890
+
+    def test_model_url_with_name_and_version(self):
+        """Parses model URL with name and version."""
+        model_id, version_id = parse_civitai_url(
+            "https://civitai.com/models/12345/model-name?modelVersionId=67890"
+        )
+        assert model_id == 12345
+        assert version_id == 67890
+
+    def test_invalid_url_raises(self):
+        """Invalid URL raises ValueError."""
+        with pytest.raises(ValueError, match="Invalid Civitai URL"):
+            parse_civitai_url("https://example.com/something")
+
 
 # Sample API responses for testing
 SAMPLE_MODEL_RESPONSE = {

--- a/tests/test_embedding.py
+++ b/tests/test_embedding.py
@@ -11,47 +11,9 @@ from oneiro.pipelines.embedding import (
     EmbeddingIncompatibleError,
     EmbeddingSource,
     is_embedding_compatible,
-    parse_civitai_url,
     parse_embedding_config,
     parse_embeddings_from_config,
 )
-
-
-class TestParseCivitaiUrl:
-    """Tests for parse_civitai_url function."""
-
-    def test_basic_model_url(self):
-        """Parses basic model URL."""
-        model_id, version_id = parse_civitai_url("https://civitai.com/models/12345")
-        assert model_id == 12345
-        assert version_id is None
-
-    def test_model_url_with_name(self):
-        """Parses model URL with name slug."""
-        model_id, version_id = parse_civitai_url("https://civitai.com/models/12345/my-cool-model")
-        assert model_id == 12345
-        assert version_id is None
-
-    def test_model_url_with_version(self):
-        """Parses model URL with version ID in query string."""
-        model_id, version_id = parse_civitai_url(
-            "https://civitai.com/models/12345?modelVersionId=67890"
-        )
-        assert model_id == 12345
-        assert version_id == 67890
-
-    def test_model_url_with_name_and_version(self):
-        """Parses model URL with name and version."""
-        model_id, version_id = parse_civitai_url(
-            "https://civitai.com/models/12345/model-name?modelVersionId=67890"
-        )
-        assert model_id == 12345
-        assert version_id == 67890
-
-    def test_invalid_url_raises(self):
-        """Invalid URL raises ValueError."""
-        with pytest.raises(ValueError, match="Invalid Civitai URL"):
-            parse_civitai_url("https://example.com/something")
 
 
 class TestEmbeddingConfig:

--- a/tests/test_lora.py
+++ b/tests/test_lora.py
@@ -11,48 +11,10 @@ from oneiro.pipelines.lora import (
     LoraIncompatibleError,
     LoraSource,
     is_lora_compatible,
-    parse_civitai_url,
     parse_lora_config,
     parse_loras_from_config,
     parse_loras_from_model_config,
 )
-
-
-class TestParseCivitaiUrl:
-    """Tests for parse_civitai_url function."""
-
-    def test_basic_model_url(self):
-        """Parses basic model URL."""
-        model_id, version_id = parse_civitai_url("https://civitai.com/models/12345")
-        assert model_id == 12345
-        assert version_id is None
-
-    def test_model_url_with_name(self):
-        """Parses model URL with name slug."""
-        model_id, version_id = parse_civitai_url("https://civitai.com/models/12345/my-cool-model")
-        assert model_id == 12345
-        assert version_id is None
-
-    def test_model_url_with_version(self):
-        """Parses model URL with version ID in query string."""
-        model_id, version_id = parse_civitai_url(
-            "https://civitai.com/models/12345?modelVersionId=67890"
-        )
-        assert model_id == 12345
-        assert version_id == 67890
-
-    def test_model_url_with_name_and_version(self):
-        """Parses model URL with name and version."""
-        model_id, version_id = parse_civitai_url(
-            "https://civitai.com/models/12345/model-name?modelVersionId=67890"
-        )
-        assert model_id == 12345
-        assert version_id == 67890
-
-    def test_invalid_url_raises(self):
-        """Invalid URL raises ValueError."""
-        with pytest.raises(ValueError, match="Invalid Civitai URL"):
-            parse_civitai_url("https://example.com/something")
 
 
 class TestLoraConfig:


### PR DESCRIPTION
Move parse_civitai_url() from lora.py and embedding.py to civitai.py, eliminating ~60 lines of duplicate code. Update all import sites and consolidate duplicate test class.