### PR TITLE
refactor(pipelines): generate() templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,4 @@ uv.lock
 
 .beads
 .gitattributes
+.beads/artifacts/

--- a/src/oneiro/pipelines/base.py
+++ b/src/oneiro/pipelines/base.py
@@ -44,7 +44,6 @@ class BasePipeline(ABC):
             full_config: Full configuration dict (for accessing global sections like embeddings)
         """
 
-    @abstractmethod
     def generate(
         self,
         prompt: str,
@@ -56,7 +55,142 @@ class BasePipeline(ABC):
         guidance_scale: float = 0.0,
         **kwargs: Any,
     ) -> GenerationResult:
-        """Generate an image."""
+        """Generate an image using Template Method pattern.
+
+        Subclasses should override hooks (validate_pipeline, pre_generate,
+        build_generation_kwargs, run_inference, build_result, post_generate),
+        not this method.
+        """
+        self.validate_pipeline()
+        self.pre_generate(**kwargs)
+        try:
+            actual_seed, generator = self._prepare_seed(seed)
+            # Pop init_image and strength from kwargs to avoid passing twice
+            init_image = self._load_init_image(kwargs.pop("init_image", None))
+            strength = kwargs.pop("strength", 0.75)
+
+            gen_kwargs = self.build_generation_kwargs(
+                prompt=prompt,
+                negative_prompt=negative_prompt,
+                width=width,
+                height=height,
+                steps=steps,
+                guidance_scale=guidance_scale,
+                generator=generator,
+                init_image=init_image,
+                strength=strength,
+                **kwargs,
+            )
+            is_img2img = init_image is not None
+            result = self.run_inference(gen_kwargs, is_img2img)
+
+            DevicePolicy.clear_cache()
+            return self.build_result(
+                result=result,
+                seed=actual_seed,
+                prompt=prompt,
+                negative_prompt=negative_prompt,
+                steps=steps,
+                guidance_scale=guidance_scale,
+            )
+        finally:
+            self.post_generate(**kwargs)
+
+    def validate_pipeline(self) -> None:
+        """Validate pipeline is ready for generation.
+
+        This is called before pre_generate() and before any kwargs are consumed.
+        Override for additional validation checks (e.g., config state validation).
+        """
+        if self.pipe is None:
+            raise RuntimeError("Pipeline not loaded")
+
+    def pre_generate(self, **kwargs: Any) -> None:  # noqa: B027
+        """Pre-generation hook called before building kwargs.
+
+        Override for scheduler/LoRA setup or other pre-processing.
+        This is an optional hook with a no-op default; it is intentionally
+        not abstract so subclasses can choose whether to implement it.
+
+        Note: This method may pop keys from kwargs to consume them before
+        build_generation_kwargs() is called. The modified kwargs are then
+        passed through to build_generation_kwargs() and post_generate().
+        """
+        pass
+
+    @abstractmethod
+    def build_generation_kwargs(
+        self,
+        prompt: str,
+        negative_prompt: str | None,
+        width: int,
+        height: int,
+        steps: int,
+        guidance_scale: float,
+        generator: torch.Generator,
+        init_image: Image.Image | None,
+        strength: float,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        """Build pipeline-specific generation kwargs.
+
+        This is the REQUIRED hook that each subclass must implement.
+        Return a dict to be passed to self.pipe().
+        """
+
+    def run_inference(self, gen_kwargs: dict[str, Any], is_img2img: bool) -> Any:
+        """Run the diffusion pipeline.
+
+        Args:
+            gen_kwargs: Keyword arguments to pass to the underlying pipeline.
+            is_img2img: Whether this is an image-to-image generation. This flag
+                is not used by the base implementation but is provided for
+                subclasses that need to branch on img2img vs txt2img behavior.
+
+        Returns:
+            Pipeline output (typically has .images attribute).
+
+        Override if the pipeline call signature or behavior differs.
+        """
+        return self.pipe(**gen_kwargs)
+
+    def build_result(
+        self,
+        result: Any,
+        seed: int,
+        prompt: str,
+        negative_prompt: str | None,
+        steps: int,
+        guidance_scale: float,
+    ) -> GenerationResult:
+        """Build GenerationResult from pipeline output.
+
+        Override if result format differs.
+        """
+        output_image = result.images[0]
+        return GenerationResult(
+            image=output_image,
+            seed=seed,
+            prompt=prompt,
+            negative_prompt=negative_prompt,
+            width=output_image.width,
+            height=output_image.height,
+            steps=steps,
+            guidance_scale=guidance_scale,
+        )
+
+    def post_generate(self, **kwargs: Any) -> None:  # noqa: B027
+        """Post-generation cleanup hook called after generation completes.
+
+        Override for LoRA restore or other cleanup. This is an optional hook
+        with a no-op default; it is intentionally not abstract so subclasses
+        can choose whether to implement it.
+
+        Note: The kwargs passed here have already had 'init_image' and 'strength'
+        removed by generate(). If a subclass needs access to these values,
+        it should save them in pre_generate() before they are consumed.
+        """
+        pass
 
     def unload(self) -> None:
         """Free GPU memory."""

--- a/src/oneiro/pipelines/flux2.py
+++ b/src/oneiro/pipelines/flux2.py
@@ -2,6 +2,9 @@
 
 from typing import Any
 
+import torch
+from PIL import Image
+
 from oneiro.device import DevicePolicy
 from oneiro.pipelines.base import BasePipeline, GenerationResult
 from oneiro.pipelines.embedding import EmbeddingLoaderMixin, parse_embeddings_from_config
@@ -85,46 +88,48 @@ class Flux2PipelineWrapper(LoraLoaderMixin, EmbeddingLoaderMixin, BasePipeline):
         **kwargs: Any,
     ) -> GenerationResult:
         """Generate image with FLUX.2."""
-        if self.pipe is None:
-            raise RuntimeError("Pipeline not loaded")
-
-        actual_seed, generator = self._prepare_seed(seed)
-
-        # Handle img2img
-        init_image = self._load_init_image(kwargs.get("init_image"))
-        strength = kwargs.get("strength", 0.75)
-
-        if init_image:
-            print(f"FLUX.2 img2img: '{prompt[:50]}...' seed={actual_seed} strength={strength}")
-            result = self.pipe(
-                prompt=prompt,
-                image=init_image,
-                strength=strength,
-                num_inference_steps=steps,
-                guidance_scale=guidance_scale,
-                generator=generator,
-            )
-        else:
-            print(f"FLUX.2 generating: '{prompt[:50]}...' seed={actual_seed}")
-            result = self.pipe(
-                prompt=prompt,
-                height=height,
-                width=width,
-                num_inference_steps=steps,
-                guidance_scale=guidance_scale,
-                generator=generator,
-            )
-
-        DevicePolicy.clear_cache()
-
-        output_image = result.images[0]
-        return GenerationResult(
-            image=output_image,
-            seed=actual_seed,
+        return super().generate(
             prompt=prompt,
             negative_prompt=negative_prompt,
-            width=output_image.width,
-            height=output_image.height,
+            width=width,
+            height=height,
+            seed=seed,
             steps=steps,
             guidance_scale=guidance_scale,
+            **kwargs,
         )
+
+    def build_generation_kwargs(
+        self,
+        prompt: str,
+        negative_prompt: str | None,  # Not used by FLUX.2 but stored in result
+        width: int,
+        height: int,
+        steps: int,
+        guidance_scale: float,
+        generator: torch.Generator,
+        init_image: Image.Image | None,
+        strength: float,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        """Build FLUX.2 generation kwargs."""
+        if init_image:
+            print(f"FLUX.2 img2img: '{prompt[:50]}...' strength={strength}")
+            return {
+                "prompt": prompt,
+                "image": init_image,
+                "strength": strength,
+                "num_inference_steps": steps,
+                "guidance_scale": guidance_scale,
+                "generator": generator,
+            }
+        else:
+            print(f"FLUX.2 generating: '{prompt[:50]}...'")
+            return {
+                "prompt": prompt,
+                "height": height,
+                "width": width,
+                "num_inference_steps": steps,
+                "guidance_scale": guidance_scale,
+                "generator": generator,
+            }

--- a/tests/test_pipelines_base.py
+++ b/tests/test_pipelines_base.py
@@ -60,29 +60,29 @@ class ConcretePipeline(BasePipeline):
     def load(self, model_config):
         pass
 
-    def generate(
+    def build_generation_kwargs(
         self,
         prompt,
-        negative_prompt=None,
-        width=1024,
-        height=1024,
-        seed=-1,
-        steps=9,
-        guidance_scale=0.0,
+        negative_prompt,
+        width,
+        height,
+        steps,
+        guidance_scale,
+        generator,
+        init_image,
+        strength,
         **kwargs,
     ):
-        img = Image.new("RGB", (width, height))
-        actual_seed, _ = self._prepare_seed(seed)
-        return GenerationResult(
-            image=img,
-            seed=actual_seed,
-            prompt=prompt,
-            negative_prompt=negative_prompt,
-            width=width,
-            height=height,
-            steps=steps,
-            guidance_scale=guidance_scale,
-        )
+        """Build generation kwargs for testing."""
+        return {
+            "prompt": prompt,
+            "negative_prompt": negative_prompt,
+            "width": width,
+            "height": height,
+            "num_inference_steps": steps,
+            "guidance_scale": guidance_scale,
+            "generator": generator,
+        }
 
 
 class TestBasePipelineInit:

--- a/tests/test_pipelines_flux2.py
+++ b/tests/test_pipelines_flux2.py
@@ -1,0 +1,264 @@
+"""Tests for pipelines.flux2 module."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+from PIL import Image
+
+from oneiro.device import DevicePolicy, OffloadMode
+from oneiro.pipelines.flux2 import Flux2PipelineWrapper
+
+
+class TestFlux2PipelineWrapperInit:
+    """Tests for Flux2PipelineWrapper initialization."""
+
+    def test_init_creates_instance(self):
+        """Flux2PipelineWrapper can be instantiated."""
+        mock_policy = DevicePolicy(device="cpu", dtype=torch.float32, offload=OffloadMode.NEVER)
+        with patch.object(DevicePolicy, "auto_detect", return_value=mock_policy):
+            pipeline = Flux2PipelineWrapper()
+        assert pipeline.pipe is None
+        assert pipeline.policy.device == "cpu"
+
+
+class TestFlux2PipelineWrapperLoad:
+    """Tests for Flux2PipelineWrapper.load()."""
+
+    @patch("oneiro.pipelines.base.torch.set_num_interop_threads")
+    @patch("oneiro.pipelines.base.torch.set_num_threads")
+    @patch("transformers.Mistral3ForConditionalGeneration")
+    @patch("diffusers.Flux2Transformer2DModel")
+    @patch("diffusers.Flux2Pipeline")
+    def test_load_with_default_repo(
+        self, mock_flux2_pipeline, mock_transformer, mock_text_encoder, mock_threads, mock_interop
+    ):
+        """Load uses default repo when not specified."""
+        mock_pipe = MagicMock()
+        mock_flux2_pipeline.from_pretrained.return_value = mock_pipe
+        mock_transformer.from_pretrained.return_value = MagicMock()
+        mock_text_encoder.from_pretrained.return_value = MagicMock()
+
+        pipeline = Flux2PipelineWrapper()
+        pipeline.load({})
+
+        mock_flux2_pipeline.from_pretrained.assert_called_once()
+        call_args = mock_flux2_pipeline.from_pretrained.call_args
+        assert call_args[0][0] == "diffusers/FLUX.2-dev-bnb-4bit"
+
+    @patch("oneiro.pipelines.base.torch.set_num_interop_threads")
+    @patch("oneiro.pipelines.base.torch.set_num_threads")
+    @patch("transformers.Mistral3ForConditionalGeneration")
+    @patch("diffusers.Flux2Transformer2DModel")
+    @patch("diffusers.Flux2Pipeline")
+    def test_load_with_custom_repo(
+        self, mock_flux2_pipeline, mock_transformer, mock_text_encoder, mock_threads, mock_interop
+    ):
+        """Load uses custom repo from config."""
+        mock_pipe = MagicMock()
+        mock_flux2_pipeline.from_pretrained.return_value = mock_pipe
+        mock_transformer.from_pretrained.return_value = MagicMock()
+        mock_text_encoder.from_pretrained.return_value = MagicMock()
+
+        pipeline = Flux2PipelineWrapper()
+        pipeline.load({"repo": "custom/flux2-model"})
+
+        call_args = mock_flux2_pipeline.from_pretrained.call_args
+        assert call_args[0][0] == "custom/flux2-model"
+
+    @patch("oneiro.pipelines.base.torch.set_num_interop_threads")
+    @patch("oneiro.pipelines.base.torch.set_num_threads")
+    @patch("transformers.Mistral3ForConditionalGeneration")
+    @patch("diffusers.Flux2Transformer2DModel")
+    @patch("diffusers.Flux2Pipeline")
+    def test_load_enables_cpu_offload_on_cuda(
+        self, mock_flux2_pipeline, mock_transformer, mock_text_encoder, mock_threads, mock_interop
+    ):
+        """Load enables CPU offload on CUDA by default."""
+        mock_pipe = MagicMock()
+        mock_flux2_pipeline.from_pretrained.return_value = mock_pipe
+        mock_transformer.from_pretrained.return_value = MagicMock()
+        mock_text_encoder.from_pretrained.return_value = MagicMock()
+
+        # Mock CUDA being available
+        mock_policy = DevicePolicy(device="cuda", dtype=torch.float16, offload=OffloadMode.AUTO)
+        with patch.object(DevicePolicy, "auto_detect", return_value=mock_policy):
+            pipeline = Flux2PipelineWrapper()
+            pipeline.load({})
+
+        mock_pipe.enable_model_cpu_offload.assert_called_once()
+
+    @patch("oneiro.pipelines.base.torch.set_num_interop_threads")
+    @patch("oneiro.pipelines.base.torch.set_num_threads")
+    @patch("transformers.Mistral3ForConditionalGeneration")
+    @patch("diffusers.Flux2Transformer2DModel")
+    @patch("diffusers.Flux2Pipeline")
+    def test_load_disables_cpu_offload_when_configured(
+        self, mock_flux2_pipeline, mock_transformer, mock_text_encoder, mock_threads, mock_interop
+    ):
+        """Load respects cpu_offload=False config."""
+        mock_pipe = MagicMock()
+        mock_flux2_pipeline.from_pretrained.return_value = mock_pipe
+        mock_transformer.from_pretrained.return_value = MagicMock()
+        mock_text_encoder.from_pretrained.return_value = MagicMock()
+
+        pipeline = Flux2PipelineWrapper()
+        pipeline.load({"cpu_offload": False})
+
+        mock_pipe.enable_model_cpu_offload.assert_not_called()
+
+
+class TestFlux2PipelineWrapperGenerate:
+    """Tests for Flux2PipelineWrapper.generate()."""
+
+    def test_generate_raises_when_not_loaded(self):
+        """Generate raises RuntimeError when pipeline not loaded."""
+        mock_policy = DevicePolicy(device="cpu", dtype=torch.float32, offload=OffloadMode.NEVER)
+        with patch.object(DevicePolicy, "auto_detect", return_value=mock_policy):
+            pipeline = Flux2PipelineWrapper()
+            with pytest.raises(RuntimeError, match="Pipeline not loaded"):
+                pipeline.generate("test prompt")
+
+    def test_generate_returns_result(self):
+        """Generate returns GenerationResult with correct fields."""
+        mock_policy = DevicePolicy(device="cpu", dtype=torch.float32, offload=OffloadMode.NEVER)
+        with patch.object(DevicePolicy, "auto_detect", return_value=mock_policy):
+            pipeline = Flux2PipelineWrapper()
+            mock_pipe = MagicMock()
+            mock_image = Image.new("RGB", (1024, 1024), color="blue")
+            mock_pipe.return_value.images = [mock_image]
+            pipeline.pipe = mock_pipe
+
+            result = pipeline.generate("a beautiful landscape", seed=42)
+
+            assert result.image is mock_image
+            assert result.seed == 42
+            assert result.prompt == "a beautiful landscape"
+            assert result.width == 1024
+            assert result.height == 1024
+
+    def test_generate_uses_default_parameters(self):
+        """Generate uses correct default parameters for FLUX.2."""
+        mock_policy = DevicePolicy(device="cpu", dtype=torch.float32, offload=OffloadMode.NEVER)
+        with patch.object(DevicePolicy, "auto_detect", return_value=mock_policy):
+            pipeline = Flux2PipelineWrapper()
+            mock_pipe = MagicMock()
+            mock_image = Image.new("RGB", (1024, 1024))
+            mock_pipe.return_value.images = [mock_image]
+            pipeline.pipe = mock_pipe
+
+            pipeline.generate("test prompt", seed=42)
+
+            call_kwargs = mock_pipe.call_args[1]
+            assert call_kwargs["num_inference_steps"] == 28
+            assert call_kwargs["guidance_scale"] == 4.0
+
+    def test_generate_with_custom_parameters(self):
+        """Generate respects custom parameters."""
+        mock_policy = DevicePolicy(device="cpu", dtype=torch.float32, offload=OffloadMode.NEVER)
+        with patch.object(DevicePolicy, "auto_detect", return_value=mock_policy):
+            pipeline = Flux2PipelineWrapper()
+            mock_pipe = MagicMock()
+            mock_image = Image.new("RGB", (512, 512))
+            mock_pipe.return_value.images = [mock_image]
+            pipeline.pipe = mock_pipe
+
+            result = pipeline.generate(
+                "test prompt",
+                width=512,
+                height=512,
+                seed=123,
+                steps=20,
+                guidance_scale=5.0,
+            )
+
+            call_kwargs = mock_pipe.call_args[1]
+            assert call_kwargs["width"] == 512
+            assert call_kwargs["height"] == 512
+            assert call_kwargs["num_inference_steps"] == 20
+            assert call_kwargs["guidance_scale"] == 5.0
+            assert result.steps == 20
+            assert result.guidance_scale == 5.0
+
+    def test_generate_stores_negative_prompt_in_result(self):
+        """Generate stores negative_prompt in result but does NOT pass it to pipeline."""
+        mock_policy = DevicePolicy(device="cpu", dtype=torch.float32, offload=OffloadMode.NEVER)
+        with patch.object(DevicePolicy, "auto_detect", return_value=mock_policy):
+            pipeline = Flux2PipelineWrapper()
+            mock_pipe = MagicMock()
+            mock_image = Image.new("RGB", (1024, 1024))
+            mock_pipe.return_value.images = [mock_image]
+            pipeline.pipe = mock_pipe
+
+            result = pipeline.generate("test prompt", negative_prompt="blurry", seed=42)
+
+            assert result.negative_prompt == "blurry"
+            call_kwargs = mock_pipe.call_args[1]
+            assert "negative_prompt" not in call_kwargs
+
+    def test_generate_random_seed_when_negative(self):
+        """Generate uses random seed when seed < 0."""
+        mock_policy = DevicePolicy(device="cpu", dtype=torch.float32, offload=OffloadMode.NEVER)
+        with patch.object(DevicePolicy, "auto_detect", return_value=mock_policy):
+            pipeline = Flux2PipelineWrapper()
+            mock_pipe = MagicMock()
+            mock_image = Image.new("RGB", (1024, 1024))
+            mock_pipe.return_value.images = [mock_image]
+            pipeline.pipe = mock_pipe
+
+            result = pipeline.generate("test prompt", seed=-1)
+
+            assert result.seed >= 0
+            assert result.seed < 2**32
+
+
+class TestFlux2PipelineWrapperImg2Img:
+    """Tests for Flux2PipelineWrapper img2img functionality."""
+
+    def test_generate_with_init_image(self):
+        """Generate supports img2img with init_image."""
+        import io
+
+        mock_policy = DevicePolicy(device="cpu", dtype=torch.float32, offload=OffloadMode.NEVER)
+        with patch.object(DevicePolicy, "auto_detect", return_value=mock_policy):
+            pipeline = Flux2PipelineWrapper()
+            mock_pipe = MagicMock()
+            mock_output = Image.new("RGB", (1024, 1024))
+            mock_pipe.return_value.images = [mock_output]
+            pipeline.pipe = mock_pipe
+
+            # Create init image bytes
+            init_img = Image.new("RGB", (512, 512), color="red")
+            buffer = io.BytesIO()
+            init_img.save(buffer, format="PNG")
+            init_bytes = buffer.getvalue()
+
+            result = pipeline.generate("test prompt", seed=42, init_image=init_bytes)
+
+            call_kwargs = mock_pipe.call_args[1]
+            assert "image" in call_kwargs
+            assert call_kwargs["strength"] == 0.75  # default strength
+            assert result.prompt == "test prompt"
+
+    def test_generate_with_custom_strength(self):
+        """Generate respects custom strength for img2img."""
+        import io
+
+        mock_policy = DevicePolicy(device="cpu", dtype=torch.float32, offload=OffloadMode.NEVER)
+        with patch.object(DevicePolicy, "auto_detect", return_value=mock_policy):
+            pipeline = Flux2PipelineWrapper()
+            mock_pipe = MagicMock()
+            mock_output = Image.new("RGB", (1024, 1024))
+            mock_pipe.return_value.images = [mock_output]
+            pipeline.pipe = mock_pipe
+
+            # Create init image bytes
+            init_img = Image.new("RGB", (512, 512), color="red")
+            buffer = io.BytesIO()
+            init_img.save(buffer, format="PNG")
+            init_bytes = buffer.getvalue()
+
+            pipeline.generate("test prompt", seed=42, init_image=init_bytes, strength=0.5)
+
+            call_kwargs = mock_pipe.call_args[1]
+            assert call_kwargs["strength"] == 0.5

--- a/tests/test_pipelines_qwen.py
+++ b/tests/test_pipelines_qwen.py
@@ -1,0 +1,354 @@
+"""Tests for pipelines.qwen module."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+from PIL import Image
+
+from oneiro.device import DevicePolicy, OffloadMode
+from oneiro.pipelines.qwen import QwenPipelineWrapper
+
+
+class TestQwenPipelineWrapperInit:
+    """Tests for QwenPipelineWrapper initialization."""
+
+    def test_init_creates_instance(self):
+        """QwenPipelineWrapper can be instantiated."""
+        mock_policy = DevicePolicy(device="cpu", dtype=torch.float32, offload=OffloadMode.NEVER)
+        with patch.object(DevicePolicy, "auto_detect", return_value=mock_policy):
+            pipeline = QwenPipelineWrapper()
+        assert pipeline.pipe is None
+        assert pipeline.policy.device == "cpu"
+
+
+class TestQwenPipelineWrapperParseTransformerPath:
+    """Tests for QwenPipelineWrapper._parse_transformer_path()."""
+
+    def test_local_path_gguf(self, tmp_path):
+        """Local GGUF path is detected correctly."""
+        gguf_file = tmp_path / "model.gguf"
+        gguf_file.touch()
+
+        pipeline = QwenPipelineWrapper()
+        path, is_gguf = pipeline._parse_transformer_path(str(gguf_file))
+
+        assert path == str(gguf_file)
+        assert is_gguf is True
+
+    def test_local_path_non_gguf(self, tmp_path):
+        """Local non-GGUF path is detected correctly."""
+        safetensors_file = tmp_path / "model.safetensors"
+        safetensors_file.touch()
+
+        pipeline = QwenPipelineWrapper()
+        path, is_gguf = pipeline._parse_transformer_path(str(safetensors_file))
+
+        assert path == str(safetensors_file)
+        assert is_gguf is False
+
+    def test_hf_hub_format_gguf(self):
+        """HF Hub repo:file format with GGUF is parsed correctly."""
+        pipeline = QwenPipelineWrapper()
+
+        with patch("huggingface_hub.hf_hub_download") as mock_download:
+            mock_download.return_value = "/cache/model.gguf"
+            path, is_gguf = pipeline._parse_transformer_path(
+                "unsloth/Qwen-Image-GGUF:qwen-image-Q4_K_S.gguf"
+            )
+
+        mock_download.assert_called_once_with(
+            repo_id="unsloth/Qwen-Image-GGUF", filename="qwen-image-Q4_K_S.gguf"
+        )
+        assert path == "/cache/model.gguf"
+        assert is_gguf is True
+
+    def test_invalid_format_raises(self):
+        """Invalid format raises ValueError."""
+        pipeline = QwenPipelineWrapper()
+
+        with pytest.raises(ValueError, match="must be 'repo_id:filename' or a local path"):
+            pipeline._parse_transformer_path("invalid_format")
+
+
+class TestQwenPipelineWrapperLoad:
+    """Tests for QwenPipelineWrapper.load()."""
+
+    @patch("diffusers.FlowMatchEulerDiscreteScheduler")
+    @patch("diffusers.DiffusionPipeline")
+    def test_load_with_default_repo(self, mock_diffusion_pipeline, mock_scheduler):
+        """Load uses default repo when not specified."""
+        mock_pipe = MagicMock()
+        mock_diffusion_pipeline.from_pretrained.return_value = mock_pipe
+        mock_scheduler.from_config.return_value = MagicMock()
+
+        pipeline = QwenPipelineWrapper()
+        pipeline.load({})
+
+        mock_diffusion_pipeline.from_pretrained.assert_called_once()
+        call_args = mock_diffusion_pipeline.from_pretrained.call_args
+        assert call_args[0][0] == "Qwen/Qwen-Image"
+
+    @patch("diffusers.FlowMatchEulerDiscreteScheduler")
+    @patch("diffusers.DiffusionPipeline")
+    def test_load_with_custom_repo(self, mock_diffusion_pipeline, mock_scheduler):
+        """Load uses custom repo from config."""
+        mock_pipe = MagicMock()
+        mock_diffusion_pipeline.from_pretrained.return_value = mock_pipe
+        mock_scheduler.from_config.return_value = MagicMock()
+
+        pipeline = QwenPipelineWrapper()
+        pipeline.load({"repo": "custom/qwen-model"})
+
+        call_args = mock_diffusion_pipeline.from_pretrained.call_args
+        assert call_args[0][0] == "custom/qwen-model"
+
+    @patch("diffusers.FlowMatchEulerDiscreteScheduler")
+    @patch("diffusers.DiffusionPipeline")
+    def test_load_enables_cpu_offload_on_cuda(self, mock_diffusion_pipeline, mock_scheduler):
+        """Load enables CPU offload on CUDA by default."""
+        mock_pipe = MagicMock()
+        mock_diffusion_pipeline.from_pretrained.return_value = mock_pipe
+        mock_scheduler.from_config.return_value = MagicMock()
+
+        # Mock CUDA being available
+        mock_policy = DevicePolicy(device="cuda", dtype=torch.float16, offload=OffloadMode.AUTO)
+        with patch.object(DevicePolicy, "auto_detect", return_value=mock_policy):
+            pipeline = QwenPipelineWrapper()
+            pipeline.load({})
+
+        mock_pipe.enable_model_cpu_offload.assert_called_once()
+
+    @patch("diffusers.FlowMatchEulerDiscreteScheduler")
+    @patch("diffusers.DiffusionPipeline")
+    def test_load_disables_cpu_offload_when_configured(
+        self, mock_diffusion_pipeline, mock_scheduler
+    ):
+        """Load respects cpu_offload=False config."""
+        mock_pipe = MagicMock()
+        mock_diffusion_pipeline.from_pretrained.return_value = mock_pipe
+        mock_scheduler.from_config.return_value = MagicMock()
+
+        pipeline = QwenPipelineWrapper()
+        pipeline.load({"cpu_offload": False})
+
+        mock_pipe.enable_model_cpu_offload.assert_not_called()
+
+
+class TestQwenPipelineWrapperGenerate:
+    """Tests for QwenPipelineWrapper.generate()."""
+
+    def test_generate_raises_when_not_loaded(self):
+        """Generate raises RuntimeError when pipeline not loaded."""
+        mock_policy = DevicePolicy(device="cpu", dtype=torch.float32, offload=OffloadMode.NEVER)
+        with patch.object(DevicePolicy, "auto_detect", return_value=mock_policy):
+            pipeline = QwenPipelineWrapper()
+            with pytest.raises(RuntimeError, match="Pipeline not loaded"):
+                pipeline.generate("test prompt")
+
+    def test_generate_returns_result(self):
+        """Generate returns GenerationResult with correct fields."""
+        mock_policy = DevicePolicy(device="cpu", dtype=torch.float32, offload=OffloadMode.NEVER)
+        with patch.object(DevicePolicy, "auto_detect", return_value=mock_policy):
+            pipeline = QwenPipelineWrapper()
+            mock_pipe = MagicMock()
+            mock_image = Image.new("RGB", (1024, 1024), color="blue")
+            mock_pipe.return_value.images = [mock_image]
+            pipeline.pipe = mock_pipe
+
+            result = pipeline.generate("a beautiful landscape", seed=42)
+
+            assert result.image is mock_image
+            assert result.seed == 42
+            assert result.prompt == "a beautiful landscape"
+            assert result.width == 1024
+            assert result.height == 1024
+
+    def test_generate_uses_true_cfg_scale(self):
+        """Generate uses true_cfg_scale instead of guidance_scale."""
+        mock_policy = DevicePolicy(device="cpu", dtype=torch.float32, offload=OffloadMode.NEVER)
+        with patch.object(DevicePolicy, "auto_detect", return_value=mock_policy):
+            pipeline = QwenPipelineWrapper()
+            mock_pipe = MagicMock()
+            mock_image = Image.new("RGB", (1024, 1024))
+            mock_pipe.return_value.images = [mock_image]
+            pipeline.pipe = mock_pipe
+
+            pipeline.generate("test prompt", seed=42, guidance_scale=5.0)
+
+            call_kwargs = mock_pipe.call_args[1]
+            assert "true_cfg_scale" in call_kwargs
+            assert call_kwargs["true_cfg_scale"] == 5.0
+            assert "guidance_scale" not in call_kwargs
+
+    def test_generate_accepts_true_cfg_scale_kwarg(self):
+        """Generate accepts true_cfg_scale as explicit kwarg."""
+        mock_policy = DevicePolicy(device="cpu", dtype=torch.float32, offload=OffloadMode.NEVER)
+        with patch.object(DevicePolicy, "auto_detect", return_value=mock_policy):
+            pipeline = QwenPipelineWrapper()
+            mock_pipe = MagicMock()
+            mock_image = Image.new("RGB", (1024, 1024))
+            mock_pipe.return_value.images = [mock_image]
+            pipeline.pipe = mock_pipe
+
+            # true_cfg_scale should override guidance_scale
+            pipeline.generate("test prompt", seed=42, guidance_scale=4.0, true_cfg_scale=7.0)
+
+            call_kwargs = mock_pipe.call_args[1]
+            assert call_kwargs["true_cfg_scale"] == 7.0
+
+    def test_generate_requires_negative_prompt(self):
+        """Generate defaults negative_prompt to single space when not provided."""
+        mock_policy = DevicePolicy(device="cpu", dtype=torch.float32, offload=OffloadMode.NEVER)
+        with patch.object(DevicePolicy, "auto_detect", return_value=mock_policy):
+            pipeline = QwenPipelineWrapper()
+            mock_pipe = MagicMock()
+            mock_image = Image.new("RGB", (1024, 1024))
+            mock_pipe.return_value.images = [mock_image]
+            pipeline.pipe = mock_pipe
+
+            pipeline.generate("test prompt", seed=42)
+
+            call_kwargs = mock_pipe.call_args[1]
+            assert call_kwargs["negative_prompt"] == " "
+
+    def test_generate_passes_negative_prompt(self):
+        """Generate passes user-provided negative_prompt."""
+        mock_policy = DevicePolicy(device="cpu", dtype=torch.float32, offload=OffloadMode.NEVER)
+        with patch.object(DevicePolicy, "auto_detect", return_value=mock_policy):
+            pipeline = QwenPipelineWrapper()
+            mock_pipe = MagicMock()
+            mock_image = Image.new("RGB", (1024, 1024))
+            mock_pipe.return_value.images = [mock_image]
+            pipeline.pipe = mock_pipe
+
+            result = pipeline.generate("test prompt", negative_prompt="blurry", seed=42)
+
+            call_kwargs = mock_pipe.call_args[1]
+            assert call_kwargs["negative_prompt"] == "blurry"
+            assert result.negative_prompt == "blurry"
+
+    def test_generate_uses_num_images_per_prompt(self):
+        """Generate passes num_images_per_prompt=1."""
+        mock_policy = DevicePolicy(device="cpu", dtype=torch.float32, offload=OffloadMode.NEVER)
+        with patch.object(DevicePolicy, "auto_detect", return_value=mock_policy):
+            pipeline = QwenPipelineWrapper()
+            mock_pipe = MagicMock()
+            mock_image = Image.new("RGB", (1024, 1024))
+            mock_pipe.return_value.images = [mock_image]
+            pipeline.pipe = mock_pipe
+
+            pipeline.generate("test prompt", seed=42)
+
+            call_kwargs = mock_pipe.call_args[1]
+            assert call_kwargs["num_images_per_prompt"] == 1
+
+    def test_generate_uses_default_parameters(self):
+        """Generate uses correct default parameters for Qwen-Image."""
+        mock_policy = DevicePolicy(device="cpu", dtype=torch.float32, offload=OffloadMode.NEVER)
+        with patch.object(DevicePolicy, "auto_detect", return_value=mock_policy):
+            pipeline = QwenPipelineWrapper()
+            mock_pipe = MagicMock()
+            mock_image = Image.new("RGB", (1024, 1024))
+            mock_pipe.return_value.images = [mock_image]
+            pipeline.pipe = mock_pipe
+
+            pipeline.generate("test prompt", seed=42)
+
+            call_kwargs = mock_pipe.call_args[1]
+            assert call_kwargs["num_inference_steps"] == 8
+            assert call_kwargs["true_cfg_scale"] == 4.0
+
+    def test_generate_with_custom_parameters(self):
+        """Generate respects custom parameters."""
+        mock_policy = DevicePolicy(device="cpu", dtype=torch.float32, offload=OffloadMode.NEVER)
+        with patch.object(DevicePolicy, "auto_detect", return_value=mock_policy):
+            pipeline = QwenPipelineWrapper()
+            mock_pipe = MagicMock()
+            mock_image = Image.new("RGB", (512, 512))
+            mock_pipe.return_value.images = [mock_image]
+            pipeline.pipe = mock_pipe
+
+            result = pipeline.generate(
+                "test prompt",
+                width=512,
+                height=512,
+                seed=123,
+                steps=20,
+                guidance_scale=5.0,
+            )
+
+            call_kwargs = mock_pipe.call_args[1]
+            assert call_kwargs["width"] == 512
+            assert call_kwargs["height"] == 512
+            assert call_kwargs["num_inference_steps"] == 20
+            assert call_kwargs["true_cfg_scale"] == 5.0
+            assert result.steps == 20
+
+    def test_generate_random_seed_when_negative(self):
+        """Generate uses random seed when seed < 0."""
+        mock_policy = DevicePolicy(device="cpu", dtype=torch.float32, offload=OffloadMode.NEVER)
+        with patch.object(DevicePolicy, "auto_detect", return_value=mock_policy):
+            pipeline = QwenPipelineWrapper()
+            mock_pipe = MagicMock()
+            mock_image = Image.new("RGB", (1024, 1024))
+            mock_pipe.return_value.images = [mock_image]
+            pipeline.pipe = mock_pipe
+
+            result = pipeline.generate("test prompt", seed=-1)
+
+            assert result.seed >= 0
+            assert result.seed < 2**32
+
+
+class TestQwenPipelineWrapperImg2Img:
+    """Tests for QwenPipelineWrapper img2img functionality."""
+
+    def test_generate_with_init_image(self):
+        """Generate supports img2img with init_image."""
+        import io
+
+        mock_policy = DevicePolicy(device="cpu", dtype=torch.float32, offload=OffloadMode.NEVER)
+        with patch.object(DevicePolicy, "auto_detect", return_value=mock_policy):
+            pipeline = QwenPipelineWrapper()
+            mock_pipe = MagicMock()
+            mock_output = Image.new("RGB", (1024, 1024))
+            mock_pipe.return_value.images = [mock_output]
+            pipeline.pipe = mock_pipe
+
+            # Create init image bytes
+            init_img = Image.new("RGB", (512, 512), color="red")
+            buffer = io.BytesIO()
+            init_img.save(buffer, format="PNG")
+            init_bytes = buffer.getvalue()
+
+            result = pipeline.generate("test prompt", seed=42, init_image=init_bytes)
+
+            call_kwargs = mock_pipe.call_args[1]
+            assert "image" in call_kwargs
+            assert call_kwargs["strength"] == 0.75  # default strength
+            assert call_kwargs["true_cfg_scale"] == 4.0
+            assert result.prompt == "test prompt"
+
+    def test_generate_with_custom_strength(self):
+        """Generate respects custom strength for img2img."""
+        import io
+
+        mock_policy = DevicePolicy(device="cpu", dtype=torch.float32, offload=OffloadMode.NEVER)
+        with patch.object(DevicePolicy, "auto_detect", return_value=mock_policy):
+            pipeline = QwenPipelineWrapper()
+            mock_pipe = MagicMock()
+            mock_output = Image.new("RGB", (1024, 1024))
+            mock_pipe.return_value.images = [mock_output]
+            pipeline.pipe = mock_pipe
+
+            # Create init image bytes
+            init_img = Image.new("RGB", (512, 512), color="red")
+            buffer = io.BytesIO()
+            init_img.save(buffer, format="PNG")
+            init_bytes = buffer.getvalue()
+
+            pipeline.generate("test prompt", seed=42, init_image=init_bytes, strength=0.5)
+
+            call_kwargs = mock_pipe.call_args[1]
+            assert call_kwargs["strength"] == 0.5

--- a/tests/test_pipelines_zimage.py
+++ b/tests/test_pipelines_zimage.py
@@ -1,0 +1,247 @@
+"""Tests for pipelines.zimage module."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+from PIL import Image
+
+from oneiro.device import DevicePolicy, OffloadMode
+from oneiro.pipelines.zimage import ZImagePipelineWrapper
+
+
+class TestZImagePipelineWrapperInit:
+    """Tests for ZImagePipelineWrapper initialization."""
+
+    def test_init_creates_instance(self):
+        """ZImagePipelineWrapper can be instantiated."""
+        mock_policy = DevicePolicy(device="cpu", dtype=torch.float32, offload=OffloadMode.NEVER)
+        with patch.object(DevicePolicy, "auto_detect", return_value=mock_policy):
+            pipeline = ZImagePipelineWrapper()
+        assert pipeline.pipe is None
+        assert pipeline.policy.device == "cpu"
+
+
+class TestZImagePipelineWrapperLoad:
+    """Tests for ZImagePipelineWrapper.load()."""
+
+    @patch("diffusers.ZImagePipeline")
+    def test_load_with_default_repo(self, mock_zimage_pipeline):
+        """Load uses default repo when not specified."""
+        mock_pipe = MagicMock()
+        mock_zimage_pipeline.from_pretrained.return_value = mock_pipe
+
+        pipeline = ZImagePipelineWrapper()
+        pipeline.load({})
+
+        mock_zimage_pipeline.from_pretrained.assert_called_once()
+        call_args = mock_zimage_pipeline.from_pretrained.call_args
+        assert call_args[0][0] == "Tongyi-MAI/Z-Image-Turbo"
+
+    @patch("diffusers.ZImagePipeline")
+    def test_load_with_custom_repo(self, mock_zimage_pipeline):
+        """Load uses custom repo from config."""
+        mock_pipe = MagicMock()
+        mock_zimage_pipeline.from_pretrained.return_value = mock_pipe
+
+        pipeline = ZImagePipelineWrapper()
+        pipeline.load({"repo": "custom/z-image"})
+
+        call_args = mock_zimage_pipeline.from_pretrained.call_args
+        assert call_args[0][0] == "custom/z-image"
+
+    @patch("diffusers.ZImagePipeline")
+    def test_load_enables_cpu_offload_on_cuda(self, mock_zimage_pipeline):
+        """Load enables CPU offload on CUDA by default."""
+        mock_pipe = MagicMock()
+        mock_zimage_pipeline.from_pretrained.return_value = mock_pipe
+
+        # Mock CUDA being available
+        mock_policy = DevicePolicy(device="cuda", dtype=torch.float16, offload=OffloadMode.AUTO)
+        with patch.object(DevicePolicy, "auto_detect", return_value=mock_policy):
+            pipeline = ZImagePipelineWrapper()
+            pipeline.load({})
+
+        mock_pipe.enable_model_cpu_offload.assert_called_once()
+
+    @patch("diffusers.ZImagePipeline")
+    def test_load_disables_cpu_offload_when_configured(self, mock_zimage_pipeline):
+        """Load respects cpu_offload=False config."""
+        mock_pipe = MagicMock()
+        mock_zimage_pipeline.from_pretrained.return_value = mock_pipe
+
+        pipeline = ZImagePipelineWrapper()
+        pipeline.load({"cpu_offload": False})
+
+        mock_pipe.enable_model_cpu_offload.assert_not_called()
+
+
+class TestZImagePipelineWrapperGenerate:
+    """Tests for ZImagePipelineWrapper.generate()."""
+
+    def test_generate_raises_when_not_loaded(self):
+        """Generate raises RuntimeError when pipeline not loaded."""
+        mock_policy = DevicePolicy(device="cpu", dtype=torch.float32, offload=OffloadMode.NEVER)
+        with patch.object(DevicePolicy, "auto_detect", return_value=mock_policy):
+            pipeline = ZImagePipelineWrapper()
+            with pytest.raises(RuntimeError, match="Pipeline not loaded"):
+                pipeline.generate("test prompt")
+
+    def test_generate_returns_result(self):
+        """Generate returns GenerationResult with correct fields."""
+        mock_policy = DevicePolicy(device="cpu", dtype=torch.float32, offload=OffloadMode.NEVER)
+        with patch.object(DevicePolicy, "auto_detect", return_value=mock_policy):
+            pipeline = ZImagePipelineWrapper()
+            mock_pipe = MagicMock()
+            mock_image = Image.new("RGB", (1024, 1024), color="blue")
+            mock_pipe.return_value.images = [mock_image]
+            pipeline.pipe = mock_pipe
+
+            result = pipeline.generate("a beautiful landscape", seed=42)
+
+            assert result.image is mock_image
+            assert result.seed == 42
+            assert result.prompt == "a beautiful landscape"
+            assert result.width == 1024
+            assert result.height == 1024
+
+    def test_generate_forces_guidance_scale_zero(self):
+        """Generate always uses guidance_scale=0.0 for Turbo model."""
+        mock_policy = DevicePolicy(device="cpu", dtype=torch.float32, offload=OffloadMode.NEVER)
+        with patch.object(DevicePolicy, "auto_detect", return_value=mock_policy):
+            pipeline = ZImagePipelineWrapper()
+            mock_pipe = MagicMock()
+            mock_image = Image.new("RGB", (1024, 1024))
+            mock_pipe.return_value.images = [mock_image]
+            pipeline.pipe = mock_pipe
+
+            # Try to pass guidance_scale=7.5, it should be forced to 0.0
+            result = pipeline.generate("test prompt", seed=42, guidance_scale=7.5)
+
+            call_kwargs = mock_pipe.call_args[1]
+            assert call_kwargs["guidance_scale"] == 0.0
+            assert result.guidance_scale == 0.0
+
+    def test_generate_uses_default_parameters(self):
+        """Generate uses correct default parameters for Z-Image-Turbo."""
+        mock_policy = DevicePolicy(device="cpu", dtype=torch.float32, offload=OffloadMode.NEVER)
+        with patch.object(DevicePolicy, "auto_detect", return_value=mock_policy):
+            pipeline = ZImagePipelineWrapper()
+            mock_pipe = MagicMock()
+            mock_image = Image.new("RGB", (1024, 1024))
+            mock_pipe.return_value.images = [mock_image]
+            pipeline.pipe = mock_pipe
+
+            pipeline.generate("test prompt", seed=42)
+
+            call_kwargs = mock_pipe.call_args[1]
+            assert call_kwargs["num_inference_steps"] == 9
+            assert call_kwargs["guidance_scale"] == 0.0
+
+    def test_generate_with_custom_parameters(self):
+        """Generate respects custom parameters (except guidance_scale)."""
+        mock_policy = DevicePolicy(device="cpu", dtype=torch.float32, offload=OffloadMode.NEVER)
+        with patch.object(DevicePolicy, "auto_detect", return_value=mock_policy):
+            pipeline = ZImagePipelineWrapper()
+            mock_pipe = MagicMock()
+            mock_image = Image.new("RGB", (512, 512))
+            mock_pipe.return_value.images = [mock_image]
+            pipeline.pipe = mock_pipe
+
+            result = pipeline.generate(
+                "test prompt",
+                width=512,
+                height=512,
+                seed=123,
+                steps=4,
+            )
+
+            call_kwargs = mock_pipe.call_args[1]
+            assert call_kwargs["width"] == 512
+            assert call_kwargs["height"] == 512
+            assert call_kwargs["num_inference_steps"] == 4
+            assert result.steps == 4
+
+    def test_generate_accepts_negative_prompt(self):
+        """Generate accepts and passes negative_prompt."""
+        mock_policy = DevicePolicy(device="cpu", dtype=torch.float32, offload=OffloadMode.NEVER)
+        with patch.object(DevicePolicy, "auto_detect", return_value=mock_policy):
+            pipeline = ZImagePipelineWrapper()
+            mock_pipe = MagicMock()
+            mock_image = Image.new("RGB", (1024, 1024))
+            mock_pipe.return_value.images = [mock_image]
+            pipeline.pipe = mock_pipe
+
+            result = pipeline.generate("test prompt", negative_prompt="blurry", seed=42)
+
+            call_kwargs = mock_pipe.call_args[1]
+            assert call_kwargs["negative_prompt"] == "blurry"
+            assert result.negative_prompt == "blurry"
+
+    def test_generate_random_seed_when_negative(self):
+        """Generate uses random seed when seed < 0."""
+        mock_policy = DevicePolicy(device="cpu", dtype=torch.float32, offload=OffloadMode.NEVER)
+        with patch.object(DevicePolicy, "auto_detect", return_value=mock_policy):
+            pipeline = ZImagePipelineWrapper()
+            mock_pipe = MagicMock()
+            mock_image = Image.new("RGB", (1024, 1024))
+            mock_pipe.return_value.images = [mock_image]
+            pipeline.pipe = mock_pipe
+
+            result = pipeline.generate("test prompt", seed=-1)
+
+            assert result.seed >= 0
+            assert result.seed < 2**32
+
+
+class TestZImagePipelineWrapperImg2Img:
+    """Tests for ZImagePipelineWrapper img2img functionality."""
+
+    def test_generate_with_init_image(self):
+        """Generate supports img2img with init_image."""
+        import io
+
+        mock_policy = DevicePolicy(device="cpu", dtype=torch.float32, offload=OffloadMode.NEVER)
+        with patch.object(DevicePolicy, "auto_detect", return_value=mock_policy):
+            pipeline = ZImagePipelineWrapper()
+            mock_pipe = MagicMock()
+            mock_output = Image.new("RGB", (1024, 1024))
+            mock_pipe.return_value.images = [mock_output]
+            pipeline.pipe = mock_pipe
+
+            # Create init image bytes
+            init_img = Image.new("RGB", (512, 512), color="red")
+            buffer = io.BytesIO()
+            init_img.save(buffer, format="PNG")
+            init_bytes = buffer.getvalue()
+
+            result = pipeline.generate("test prompt", seed=42, init_image=init_bytes)
+
+            call_kwargs = mock_pipe.call_args[1]
+            assert "image" in call_kwargs
+            assert call_kwargs["strength"] == 0.75  # default strength
+            assert call_kwargs["guidance_scale"] == 0.0  # still forced to 0.0
+            assert result.prompt == "test prompt"
+
+    def test_generate_with_custom_strength(self):
+        """Generate respects custom strength for img2img."""
+        import io
+
+        mock_policy = DevicePolicy(device="cpu", dtype=torch.float32, offload=OffloadMode.NEVER)
+        with patch.object(DevicePolicy, "auto_detect", return_value=mock_policy):
+            pipeline = ZImagePipelineWrapper()
+            mock_pipe = MagicMock()
+            mock_output = Image.new("RGB", (1024, 1024))
+            mock_pipe.return_value.images = [mock_output]
+            pipeline.pipe = mock_pipe
+
+            # Create init image bytes
+            init_img = Image.new("RGB", (512, 512), color="red")
+            buffer = io.BytesIO()
+            init_img.save(buffer, format="PNG")
+            init_bytes = buffer.getvalue()
+
+            pipeline.generate("test prompt", seed=42, init_image=init_bytes, strength=0.5)
+
+            call_kwargs = mock_pipe.call_args[1]
+            assert call_kwargs["strength"] == 0.5


### PR DESCRIPTION
Replace duplicated generate() implementations across 6 pipeline classes with a Template Method pattern in BasePipeline. Each subclass now only overrides the hooks that differ from the base implementation.

Template hooks added to BasePipeline:
- validate_pipeline(): check pipeline is loaded
- pre_generate(): setup before generation (scheduler, LoRA)
- build_generation_kwargs(): REQUIRED - build pipeline-specific kwargs
- run_inference(): run the diffusion pipeline
- build_result(): wrap output in GenerationResult
- post_generate(): cleanup after generation (LoRA restore)

Pipeline-specific behaviors preserved:
- ZImage: forces guidance_scale=0.0 for Turbo models
- Flux1: adds max_sequence_length=512
- Qwen: uses true_cfg_scale instead of guidance_scale
- CivitaiCheckpoint: full lifecycle with dynamic LoRA loading/unloading

Add comprehensive test coverage for pipeline generate() methods that were previously untested. This provides a safety net before refactoring.

- test_pipelines_zimage.py: 14 tests covering txt2img, img2img, guidance_scale=0
- test_pipelines_flux2.py: 13 tests covering standard FLUX generation
- test_pipelines_qwen.py: 21 tests covering true_cfg_scale, negative_prompt