### PR TITLE
refactor(mixins): convert mixins to cooperative __init__ pattern

### DIFF
--- a/src/oneiro/pipelines/base.py
+++ b/src/oneiro/pipelines/base.py
@@ -32,6 +32,7 @@ class BasePipeline(ABC):
     """Base class for all pipeline types."""
 
     def __init__(self) -> None:
+        super().__init__()
         self.pipe: Any = None
         self.policy: DevicePolicy = DevicePolicy.auto_detect()
 

--- a/src/oneiro/pipelines/civitai_checkpoint.py
+++ b/src/oneiro/pipelines/civitai_checkpoint.py
@@ -514,8 +514,6 @@ class CivitaiCheckpointPipeline(LoraLoaderMixin, EmbeddingLoaderMixin, BasePipel
 
     def __init__(self) -> None:
         super().__init__()
-        self._init_lora_state()
-        self._init_embedding_state()
         self._pipeline_config: PipelineConfig | None = None
         self._base_model: str | None = None
         self._full_config: dict[str, Any] | None = None

--- a/src/oneiro/pipelines/embedding.py
+++ b/src/oneiro/pipelines/embedding.py
@@ -405,8 +405,9 @@ class EmbeddingLoaderMixin:
     _embedding_configs: list[EmbeddingConfig]
     _loaded_tokens: list[str]
 
-    def _init_embedding_state(self) -> None:
-        """Initialize embedding-related state. Call this in __init__."""
+    def __init__(self) -> None:
+        """Initialize embedding state and continue MRO chain."""
+        super().__init__()
         self._embedding_configs = []
         self._loaded_tokens = []
 
@@ -423,9 +424,14 @@ class EmbeddingLoaderMixin:
             Token that was loaded
 
         Raises:
-            RuntimeError: If pipeline not loaded
+            RuntimeError: If pipeline not loaded or mixin not initialized
             ValueError: If embedding configuration is invalid
         """
+        if not hasattr(self, "_embedding_configs"):
+            raise RuntimeError(
+                "EmbeddingLoaderMixin not initialized. "
+                "Ensure pipeline __init__ calls super().__init__()."
+            )
         if self.pipe is None:
             raise RuntimeError("Pipeline not loaded")
 

--- a/src/oneiro/pipelines/flux2.py
+++ b/src/oneiro/pipelines/flux2.py
@@ -16,8 +16,6 @@ class Flux2PipelineWrapper(LoraLoaderMixin, EmbeddingLoaderMixin, BasePipeline):
 
     def __init__(self) -> None:
         super().__init__()
-        self._init_lora_state()
-        self._init_embedding_state()
 
     def load(self, model_config: dict[str, Any], full_config: dict[str, Any] | None = None) -> None:
         """Load FLUX.2 model with components on CPU for memory efficiency."""

--- a/src/oneiro/pipelines/lora.py
+++ b/src/oneiro/pipelines/lora.py
@@ -602,8 +602,9 @@ class LoraLoaderMixin:
     _lora_configs: list[LoraConfig]
     _loaded_adapters: list[str]
 
-    def _init_lora_state(self) -> None:
-        """Initialize LoRA-related state. Call this in __init__."""
+    def __init__(self) -> None:
+        """Initialize LoRA state and continue MRO chain."""
+        super().__init__()
         self._lora_configs = []
         self._loaded_adapters = []
 
@@ -620,9 +621,14 @@ class LoraLoaderMixin:
             Adapter name that was loaded
 
         Raises:
-            RuntimeError: If pipeline not loaded
+            RuntimeError: If pipeline not loaded or mixin not initialized
             ValueError: If LoRA configuration is invalid
         """
+        if not hasattr(self, "_lora_configs"):
+            raise RuntimeError(
+                "LoraLoaderMixin not initialized. "
+                "Ensure pipeline __init__ calls super().__init__()."
+            )
         if self.pipe is None:
             raise RuntimeError("Pipeline not loaded")
 

--- a/src/oneiro/pipelines/qwen.py
+++ b/src/oneiro/pipelines/qwen.py
@@ -18,8 +18,6 @@ class QwenPipelineWrapper(LoraLoaderMixin, EmbeddingLoaderMixin, BasePipeline):
 
     def __init__(self) -> None:
         super().__init__()
-        self._init_lora_state()
-        self._init_embedding_state()
 
     def _parse_transformer_path(self, transformer: str) -> tuple[str, bool]:
         """Parse transformer path, returning (resolved_path, is_gguf).

--- a/src/oneiro/pipelines/zimage.py
+++ b/src/oneiro/pipelines/zimage.py
@@ -16,8 +16,6 @@ class ZImagePipelineWrapper(LoraLoaderMixin, EmbeddingLoaderMixin, BasePipeline)
 
     def __init__(self) -> None:
         super().__init__()
-        self._init_lora_state()
-        self._init_embedding_state()
 
     def load(self, model_config: dict[str, Any], full_config: dict[str, Any] | None = None) -> None:
         """Load Z-Image-Turbo model."""

--- a/tests/test_embedding.py
+++ b/tests/test_embedding.py
@@ -509,8 +509,8 @@ class TestEmbeddingLoaderMixin:
 
         class MockPipeline(EmbeddingLoaderMixin):
             def __init__(self):
+                super().__init__()
                 self.pipe = Mock()
-                self._init_embedding_state()
 
         pipeline = MockPipeline()
         pipeline._loaded_tokens = ["token1", "token2"]
@@ -532,8 +532,8 @@ class TestEmbeddingLoaderMixin:
 
         class MockPipeline(EmbeddingLoaderMixin):
             def __init__(self):
+                super().__init__()
                 self.pipe = Mock()
-                self._init_embedding_state()
 
         pipeline = MockPipeline()
         pipeline._loaded_tokens = ["token1"]
@@ -547,8 +547,8 @@ class TestEmbeddingLoaderMixin:
 
         class MockPipeline(EmbeddingLoaderMixin):
             def __init__(self):
+                super().__init__()
                 self.pipe = None
-                self._init_embedding_state()
 
         pipeline = MockPipeline()
 
@@ -561,8 +561,8 @@ class TestEmbeddingLoaderMixin:
 
         class MockPipeline(EmbeddingLoaderMixin):
             def __init__(self):
+                super().__init__()
                 self.pipe = Mock()
-                self._init_embedding_state()
 
         pipeline = MockPipeline()
         pipeline._loaded_tokens = ["token1", "token2"]
@@ -583,8 +583,8 @@ class TestEmbeddingLoaderMixin:
 
         class MockPipeline(EmbeddingLoaderMixin):
             def __init__(self):
+                super().__init__()
                 self.pipe = Mock()
-                self._init_embedding_state()
 
         pipeline = MockPipeline()
 
@@ -598,8 +598,8 @@ class TestEmbeddingLoaderMixin:
 
         class MockPipeline(EmbeddingLoaderMixin):
             def __init__(self):
+                super().__init__()
                 self.pipe = None
-                self._init_embedding_state()
 
         pipeline = MockPipeline()
         pipeline._loaded_tokens = ["token1"]
@@ -614,9 +614,9 @@ class TestEmbeddingLoaderMixin:
 
         class MockPipeline(EmbeddingLoaderMixin):
             def __init__(self):
+                super().__init__()
                 self.pipe = Mock()
                 self.pipe.unload_textual_inversion.side_effect = RuntimeError("API error")
-                self._init_embedding_state()
 
         pipeline = MockPipeline()
         pipeline._loaded_tokens = ["token1"]
@@ -637,9 +637,9 @@ class TestEmbeddingLoaderMixin:
 
         class MockPipeline(EmbeddingLoaderMixin):
             def __init__(self):
+                super().__init__()
                 self.pipe = Mock()
                 self.pipe.unload_textual_inversion.side_effect = RuntimeError("API error")
-                self._init_embedding_state()
 
         pipeline = MockPipeline()
         pipeline._loaded_tokens = ["token1"]
@@ -660,8 +660,8 @@ class TestEmbeddingLoaderMixin:
 
         class MockPipeline(EmbeddingLoaderMixin):
             def __init__(self):
+                super().__init__()
                 self.pipe = Mock()
-                self._init_embedding_state()
 
         pipeline = MockPipeline()
         pipeline._loaded_tokens = ["my-embedding"]


### PR DESCRIPTION
Add self-initializing __init__ to LoraLoaderMixin and EmbeddingLoaderMixin:
- Mixin __init__ calls super().__init__() for proper MRO chain
- State initialization moved inline (no more _init_*_state())
- Invariant checks in load_single_* methods catch missing super() calls
- Add super().__init__() to BasePipeline for proper MRO chain
- Remove manual _init_lora_state() calls from 4 pipeline classes
- Remove manual _init_embedding_state() calls from 4 pipeline classes
- Mock classes in embedding tests now use cooperative __init__ to match the refactored mixin pattern.