### PR TITLE
refactor(bot): decompose bot.py

### DIFF
--- a/src/oneiro/app.py
+++ b/src/oneiro/app.py
@@ -1,0 +1,112 @@
+"""Application factory for Oneiro Discord bot."""
+
+import os
+from pathlib import Path
+from typing import Any
+
+import discord
+
+from oneiro.civitai import CivitaiClient
+from oneiro.config import Config
+from oneiro.discord.commands import register_commands
+from oneiro.discord.handlers import create_config_change_handler, handle_reaction_delete
+from oneiro.filters import ContentFilter
+from oneiro.lora_detector import AutoLoraDetector, create_detector_from_config
+from oneiro.pipelines import PipelineManager
+from oneiro.queue import GenerationQueue
+
+
+class OneiroBot(discord.Bot):
+    """Oneiro Discord bot with typed state management."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.config: Config | None = None
+        self.pipeline_manager: PipelineManager | None = None
+        self.generation_queue: GenerationQueue | None = None
+        self.content_filter: ContentFilter | None = None
+        self.civitai_client: CivitaiClient | None = None
+        self.lora_detector: AutoLoraDetector | None = None
+
+
+def create_app() -> OneiroBot:
+    """Create and wire the Discord bot with all services.
+
+    Returns:
+        Configured OneiroBot instance ready to run.
+    """
+    activity = discord.Activity(
+        name="Dreaming...",
+        type=discord.ActivityType.custom,
+    )
+
+    bot = OneiroBot(activity=activity)
+
+    # Register slash commands
+    register_commands(bot)
+
+    @bot.event
+    async def on_ready() -> None:
+        """Initialize config, pipeline and queue when bot connects."""
+        print(f"{bot.user} is online!")
+
+        # Load configuration
+        base_config_path = Path(os.environ.get("CONFIG_PATH", "config.toml"))
+        overlay_config_path = os.environ.get("CONFIG_OVERLAY_PATH")
+        state_path = os.environ.get("STATE_PATH")
+
+        bot.config = Config(
+            base_path=base_config_path,
+            overlay_path=Path(overlay_config_path) if overlay_config_path else None,
+            state_path=Path(state_path) if state_path else None,
+        )
+        bot.config.load()
+        print(f"Config loaded from {base_config_path}")
+
+        # Initialize Civitai client
+        bot.civitai_client = CivitaiClient.from_config(bot.config)
+        print("Civitai client initialized")
+
+        # Initialize content filter
+        bot.content_filter = ContentFilter(bot.config)
+        print("Content filter initialized")
+
+        # Initialize LoRA auto-detector
+        bot.lora_detector = create_detector_from_config(bot.config.data)
+        print("LoRA auto-detector initialized")
+
+        # Initialize pipeline manager with config
+        bot.pipeline_manager = PipelineManager(bot.config)
+        bot.pipeline_manager.set_civitai_client(bot.civitai_client)
+        print("Loading default model...")
+        await bot.pipeline_manager.load_model()
+        print(f"Model loaded: {bot.pipeline_manager.current_model}")
+
+        # Initialize queue with config values
+        max_global = bot.config.get("queue", "max_global", default=100)
+        max_per_user = bot.config.get("queue", "max_per_user", default=20)
+        bot.generation_queue = GenerationQueue(max_global=max_global, max_per_user=max_per_user)
+        await bot.generation_queue.start(bot.pipeline_manager)
+        print(f"Queue started: {max_global} global, {max_per_user} per user")
+
+        # Register config change callback
+        bot.config.on_change(create_config_change_handler(bot))
+
+        # Start config file watching
+        await bot.config.start_watching()
+
+        # Sync slash commands to all guilds for instant availability
+        # (global commands can take up to 1 hour to propagate)
+        if bot.guilds:
+            guild_ids = [g.id for g in bot.guilds]
+            await bot.sync_commands(guild_ids=guild_ids)
+            print(f"Commands synced to {len(guild_ids)} guild(s): {[g.name for g in bot.guilds]}")
+
+        print("Ready to generate images!")
+
+    @bot.event
+    async def on_raw_reaction_add(payload: discord.RawReactionActionEvent) -> None:
+        """Handle ❌ reaction to delete generated images."""
+        await handle_reaction_delete(bot, payload)
+
+    return bot

--- a/src/oneiro/discord/__init__.py
+++ b/src/oneiro/discord/__init__.py
@@ -1,0 +1,18 @@
+"""Discord bot components."""
+
+from oneiro.discord.commands import register_commands, slugify
+from oneiro.discord.handlers import (
+    DreamContext,
+    create_config_change_handler,
+    create_dream_callbacks,
+    handle_reaction_delete,
+)
+
+__all__ = [
+    "DreamContext",
+    "create_config_change_handler",
+    "create_dream_callbacks",
+    "handle_reaction_delete",
+    "register_commands",
+    "slugify",
+]

--- a/src/oneiro/discord/handlers.py
+++ b/src/oneiro/discord/handlers.py
@@ -1,0 +1,213 @@
+"""Event handlers and callback factories for Discord bot."""
+
+import time
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+import discord
+
+from oneiro.pipelines import GenerationResult, LoraConfig
+
+if TYPE_CHECKING:
+    from oneiro.app import OneiroBot
+    from oneiro.pipelines import PipelineManager
+
+
+@dataclass
+class DreamContext:
+    """Context for dream command callbacks.
+
+    Captures all state needed by on_start, on_position_update, on_complete.
+    Holds mutable state (status_message) that callbacks can modify.
+    """
+
+    ctx: discord.ApplicationContext
+    prompt: str
+    negative_prompt: str | None
+    current_model: str
+    scheduler: str | None
+    lora_configs: list[LoraConfig]
+    auto_detected_loras: list[tuple[str, str]]
+    is_img2img: bool
+    strength: float
+    pipeline_manager: "PipelineManager"
+    start_time: float = field(default_factory=time.time)
+    status_message: discord.Message | None = None
+
+
+def create_dream_callbacks(
+    context: DreamContext,
+) -> tuple[
+    Callable[[], Awaitable[None]],
+    Callable[[int], Awaitable[None]],
+    Callable[[GenerationResult | Exception], Awaitable[None]],
+]:
+    """Create callback closures for dream command queue submission.
+
+    Args:
+        context: DreamContext with all state needed by callbacks
+
+    Returns:
+        Tuple of (on_start, on_position_update, on_complete) callbacks
+    """
+
+    async def on_start() -> None:
+        if context.status_message:
+            try:
+                await context.status_message.edit(
+                    content=f"🎨 Generating for **{context.ctx.author.name}**..."
+                )
+            except discord.errors.NotFound:
+                pass
+
+    async def on_position_update(position: int) -> None:
+        if context.status_message:
+            try:
+                await context.status_message.edit(
+                    content=f"⏳ Queued at position **{position}**. Please wait..."
+                )
+            except discord.errors.NotFound:
+                pass
+
+    async def on_complete(result: GenerationResult | Exception) -> None:
+        if isinstance(result, Exception):
+            if context.status_message:
+                try:
+                    await context.status_message.edit(content=f"❌ Generation failed: {result}")
+                except discord.errors.NotFound:
+                    await context.ctx.followup.send(f"❌ Generation failed: {result}")
+            else:
+                await context.ctx.followup.send(f"❌ Generation failed: {result}")
+            return
+
+        elapsed = time.time() - context.start_time
+        image_buffer = context.pipeline_manager.image_to_bytes(result.image)
+        file = discord.File(image_buffer, filename="dream.png")
+
+        embed = discord.Embed(
+            title="🎨 Dream Generated" + (" (img2img)" if context.is_img2img else ""),
+            color=discord.Color.purple(),
+        )
+        embed.add_field(name="Prompt", value=context.prompt[:1024], inline=False)
+        if context.negative_prompt:
+            embed.add_field(
+                name="Negative Prompt",
+                value=context.negative_prompt[:1024],
+                inline=False,
+            )
+        embed.add_field(name="Size", value=f"{result.width}×{result.height}", inline=True)
+        embed.add_field(name="Seed", value=str(result.seed), inline=True)
+        embed.add_field(name="Time", value=f"{elapsed:.1f}s", inline=True)
+        embed.add_field(name="Model", value=f"`{context.current_model}`", inline=True)
+        embed.add_field(name="Steps", value=str(result.steps), inline=True)
+        embed.add_field(name="CFG", value=f"{result.guidance_scale:.1f}", inline=True)
+        if context.is_img2img:
+            embed.add_field(name="Strength", value=f"{context.strength:.2f}", inline=True)
+        if context.lora_configs:
+            lora_display = ", ".join(f"`{lc.name}`:{lc.weight}" for lc in context.lora_configs)
+            if len(lora_display) > 1024:
+                lora_display = lora_display[:1021] + "..."
+            embed.add_field(name="LoRA", value=lora_display, inline=True)
+        if context.auto_detected_loras:
+            auto_display = ", ".join(
+                f'`{name}` (matched "{trigger}")' for name, trigger in context.auto_detected_loras
+            )
+            if len(auto_display) > 1024:
+                auto_display = auto_display[:1021] + "..."
+            embed.add_field(name="Auto LoRAs", value=auto_display, inline=False)
+        if context.scheduler:
+            embed.add_field(name="Scheduler", value=f"`{context.scheduler}`", inline=True)
+        embed.set_image(url="attachment://dream.png")
+        embed.set_footer(
+            text=f"Requested by {context.ctx.author.name} • React ❌ to delete",
+            icon_url=context.ctx.author.avatar.url if context.ctx.author.avatar else None,
+        )
+
+        if context.status_message:
+            try:
+                await context.status_message.edit(content=None, embed=embed, file=file)
+                await context.status_message.add_reaction("❌")
+            except discord.errors.NotFound:
+                msg = await context.ctx.followup.send(embed=embed, file=file)
+                try:
+                    await msg.add_reaction("❌")  # type: ignore[union-attr]
+                except discord.errors.Forbidden:
+                    pass
+        else:
+            msg = await context.ctx.followup.send(embed=embed, file=file)
+            try:
+                await msg.add_reaction("❌")  # type: ignore[union-attr]
+            except discord.errors.Forbidden:
+                pass
+
+    return on_start, on_position_update, on_complete
+
+
+def create_config_change_handler(
+    bot: "OneiroBot",
+) -> Callable[[dict[str, Any]], Awaitable[None]]:
+    """Create a config change callback for the given bot.
+
+    Args:
+        bot: The OneiroBot instance to update on config changes
+
+    Returns:
+        Async callback function for config.on_change()
+    """
+    from oneiro.lora_detector import create_detector_from_config
+
+    async def on_config_change(new_config: dict[str, Any]) -> None:
+        if bot.generation_queue is None:
+            return
+
+        queue_config = new_config.get("queue", {})
+        new_max_global = queue_config.get("max_global", 100)
+        new_max_per_user = queue_config.get("max_per_user", 20)
+
+        if (
+            new_max_global != bot.generation_queue.max_global
+            or new_max_per_user != bot.generation_queue.max_per_user
+        ):
+            bot.generation_queue.max_global = new_max_global
+            bot.generation_queue.max_per_user = new_max_per_user
+            print(f"Queue limits updated: {new_max_global} global, {new_max_per_user} per user")
+
+        bot.lora_detector = create_detector_from_config(new_config)
+        print("LoRA auto-detector rebuilt")
+
+    return on_config_change
+
+
+async def handle_reaction_delete(
+    bot: "OneiroBot",
+    payload: discord.RawReactionActionEvent,
+) -> None:
+    """Handle ❌ reaction to delete generated images.
+
+    Args:
+        bot: The OneiroBot instance
+        payload: The reaction event payload
+    """
+    if str(payload.emoji) != "❌":
+        return
+
+    if payload.user_id == bot.user.id:  # type: ignore[union-attr]
+        return
+
+    channel = bot.get_channel(payload.channel_id)
+    if channel is None:
+        return
+
+    try:
+        message = await channel.fetch_message(payload.message_id)  # type: ignore[union-attr]
+    except discord.errors.NotFound:
+        return
+
+    if message.author != bot.user or not message.embeds:
+        return
+
+    try:
+        await message.delete()
+    except discord.errors.Forbidden:
+        pass

--- a/src/oneiro/main.py
+++ b/src/oneiro/main.py
@@ -2,7 +2,7 @@
 
 import os
 
-from oneiro.bot import create_bot
+from oneiro.app import create_app
 
 
 def main() -> None:
@@ -18,7 +18,7 @@ def main() -> None:
     if not token:
         raise ValueError("TOKEN environment variable required")
 
-    bot = create_bot()
+    bot = create_app()
     bot.run(token)
 
 

--- a/src/oneiro/services/__init__.py
+++ b/src/oneiro/services/__init__.py
@@ -1,0 +1,29 @@
+"""Business logic services."""
+
+from oneiro.services.generation import (
+    MAX_GUIDANCE_SCALE,
+    MAX_LORA_WEIGHT,
+    MAX_STEPS,
+    MIN_GUIDANCE_SCALE,
+    MIN_LORA_WEIGHT,
+    MIN_STEPS,
+    LoraNotFoundError,
+    LoraResolutionResult,
+    parse_lora_param,
+    resolve_loras,
+    validate_lora_weight,
+)
+
+__all__ = [
+    "MAX_GUIDANCE_SCALE",
+    "MAX_LORA_WEIGHT",
+    "MAX_STEPS",
+    "MIN_GUIDANCE_SCALE",
+    "MIN_LORA_WEIGHT",
+    "MIN_STEPS",
+    "LoraNotFoundError",
+    "LoraResolutionResult",
+    "parse_lora_param",
+    "resolve_loras",
+    "validate_lora_weight",
+]

--- a/src/oneiro/services/generation.py
+++ b/src/oneiro/services/generation.py
@@ -1,0 +1,243 @@
+"""Business logic for image generation - LoRA parsing and resolution."""
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+from oneiro.pipelines import LoraConfig, LoraSource
+from oneiro.pipelines.lora import is_lora_compatible
+
+if TYPE_CHECKING:
+    from oneiro.civitai import CivitaiClient
+    from oneiro.config import Config
+    from oneiro.lora_detector import AutoLoraDetector
+
+
+# LoRA weight validation limits
+MIN_LORA_WEIGHT = -2.0
+MAX_LORA_WEIGHT = 2.0
+
+# Steps validation limits (for /dream and /model commands)
+MIN_STEPS = 1
+MAX_STEPS = 100
+
+# Guidance scale validation limits (for /dream and /model commands)
+MIN_GUIDANCE_SCALE = 0.0
+MAX_GUIDANCE_SCALE = 15.0
+
+
+def validate_lora_weight(weight: float, lora_name: str) -> None:
+    """Validate that a LoRA weight is within acceptable bounds.
+
+    Args:
+        weight: The LoRA weight value to validate
+        lora_name: Name/identifier of the LoRA (for error messages)
+
+    Raises:
+        ValueError: If weight is outside the valid range [-2.0, 2.0]
+    """
+    if weight < MIN_LORA_WEIGHT or weight > MAX_LORA_WEIGHT:
+        raise ValueError(
+            f"LoRA weight {weight} for '{lora_name}' is out of range. "
+            f"Valid range is [{MIN_LORA_WEIGHT}, {MAX_LORA_WEIGHT}]."
+        )
+
+
+def parse_lora_param(lora_str: str) -> list[tuple[str, float]]:
+    """Parse lora parameter string into list of (name/id, weight) tuples.
+
+    Supports formats:
+    - "lora-name" -> ("lora-name", 1.0)
+    - "lora-name:0.8" -> ("lora-name", 0.8)
+    - "civitai:12345" -> ("civitai:12345", 1.0)
+    - "civitai:12345:0.7" -> ("civitai:12345", 0.7)
+    - "lora1:0.8,lora2:0.5" -> [("lora1", 0.8), ("lora2", 0.5)]
+
+    Args:
+        lora_str: Comma-separated lora specifications
+
+    Returns:
+        List of (identifier, weight) tuples
+
+    Raises:
+        ValueError: If a weight is outside the valid range [-2.0, 2.0]
+    """
+    results: list[tuple[str, float]] = []
+    if not lora_str:
+        return results
+
+    for part in lora_str.split(","):
+        part = part.strip()
+        if not part:
+            continue
+
+        # Check if it's a civitai: reference
+        if part.startswith("civitai:"):
+            # civitai:12345 or civitai:12345:0.8
+            segments = part.split(":")
+            if len(segments) == 2:
+                # civitai:12345
+                results.append((part, 1.0))
+            elif len(segments) >= 3:
+                # civitai:12345:0.8
+                try:
+                    weight = float(segments[2])
+                except ValueError:
+                    # Couldn't parse weight as float, treat whole thing as name
+                    results.append((part, 1.0))
+                else:
+                    lora_name = f"civitai:{segments[1]}"
+                    validate_lora_weight(weight, lora_name)
+                    results.append((lora_name, weight))
+        else:
+            # Regular name or name:weight
+            if ":" in part:
+                name, weight_str = part.rsplit(":", 1)
+                try:
+                    weight = float(weight_str)
+                except ValueError:
+                    # Couldn't parse weight as float, treat whole thing as name
+                    results.append((part, 1.0))
+                else:
+                    lora_name = name.strip()
+                    validate_lora_weight(weight, lora_name)
+                    results.append((lora_name, weight))
+            else:
+                results.append((part, 1.0))
+
+    return results
+
+
+@dataclass
+class LoraResolutionResult:
+    """Result of LoRA resolution.
+
+    Attributes:
+        configs: Resolved LoRA configurations ready for use
+        warnings: Compatibility warnings (soft warnings, don't block generation)
+        auto_detected: List of (lora_name, matched_trigger) for auto-detected LoRAs
+    """
+
+    configs: list[LoraConfig] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+    auto_detected: list[tuple[str, str]] = field(default_factory=list)
+
+
+class LoraNotFoundError(Exception):
+    """Raised when a named LoRA reference is not found in config."""
+
+    def __init__(self, lora_name: str) -> None:
+        self.lora_name = lora_name
+        super().__init__(f"Unknown LoRA: `{lora_name}`")
+
+
+async def resolve_loras(
+    lora_param: str | None,
+    prompt: str,
+    config: "Config | None",
+    civitai_client: "CivitaiClient | None",
+    lora_detector: "AutoLoraDetector | None",
+    pipeline_type: str | None,
+) -> LoraResolutionResult:
+    """Resolve LoRA specifications to configs with compatibility warnings.
+
+    If lora_param is provided, parses and resolves explicit LoRA references.
+    Otherwise, if lora_detector is available, auto-detects LoRAs from prompt.
+
+    Args:
+        lora_param: User-provided lora parameter (None for auto-detect)
+        prompt: User prompt (for auto-detection matching)
+        config: Config instance for looking up named LoRAs
+        civitai_client: Client for fetching Civitai model info (for compatibility checks)
+        lora_detector: Auto-detector for prompt-based LoRA matching
+        pipeline_type: Current pipeline type for compatibility checks
+
+    Returns:
+        LoraResolutionResult with configs, warnings, and auto-detected info
+
+    Raises:
+        ValueError: If LoRA weight is out of range
+        LoraNotFoundError: If named LoRA not found in config
+    """
+    # Import here to avoid circular import
+    from oneiro.civitai import CivitaiError
+
+    result = LoraResolutionResult()
+
+    if lora_param and config:
+        # Explicit lora parameter provided - skip auto-detection
+        parsed_loras = parse_lora_param(lora_param)
+        loras_section = config.get("loras", default={})
+
+        for lora_ref, weight in parsed_loras:
+            if lora_ref.startswith("civitai:"):
+                # Direct Civitai reference - on-demand download
+                civitai_id = int(lora_ref.split(":")[1])
+                lora_config = LoraConfig(
+                    name=f"civitai_{civitai_id}",
+                    source=LoraSource.CIVITAI,
+                    civitai_id=civitai_id,
+                    weight=weight,
+                )
+
+                # Check compatibility (soft warning)
+                if civitai_client and pipeline_type:
+                    try:
+                        model_info = await civitai_client.get_model(civitai_id)
+                        version = model_info.latest_version
+                        if version and not is_lora_compatible(pipeline_type, version.base_model):
+                            result.warnings.append(
+                                f"⚠️ LoRA `{model_info.name}` (base: {version.base_model}) "
+                                f"may not be compatible with current model ({pipeline_type})"
+                            )
+                    except CivitaiError as e:
+                        result.warnings.append(f"⚠️ Could not verify LoRA {civitai_id}: {e}")
+
+                result.configs.append(lora_config)
+            else:
+                # Named reference from config
+                if lora_ref in loras_section and isinstance(loras_section[lora_ref], dict):
+                    lora_def: dict[str, Any] = loras_section[lora_ref]
+                    source_str = lora_def.get("source", "civitai")
+                    source = LoraSource(source_str)
+
+                    lora_config = LoraConfig(
+                        name=lora_ref,
+                        source=source,
+                        weight=weight,
+                        civitai_id=lora_def.get("id") or lora_def.get("civitai_id"),
+                        civitai_version=lora_def.get("version") or lora_def.get("civitai_version"),
+                        civitai_url=lora_def.get("url") or lora_def.get("civitai_url"),
+                        repo=lora_def.get("repo"),
+                        weight_name=lora_def.get("weight_name"),
+                        path=lora_def.get("path"),
+                    )
+
+                    # Check compatibility for Civitai LoRAs
+                    if source == LoraSource.CIVITAI and civitai_client and pipeline_type:
+                        civitai_id = lora_config.civitai_id
+                        if civitai_id:
+                            try:
+                                model_info = await civitai_client.get_model(civitai_id)
+                                version = model_info.latest_version
+                                if version and not is_lora_compatible(
+                                    pipeline_type, version.base_model
+                                ):
+                                    result.warnings.append(
+                                        f"⚠️ LoRA `{lora_ref}` (base: {version.base_model}) "
+                                        f"may not be compatible with current model ({pipeline_type})"
+                                    )
+                            except CivitaiError as e:
+                                result.warnings.append(f"⚠️ Could not verify LoRA `{lora_ref}`: {e}")
+
+                    result.configs.append(lora_config)
+                else:
+                    raise LoraNotFoundError(lora_ref)
+
+    elif lora_detector and pipeline_type:
+        # No explicit lora - run auto-detection
+        matches = lora_detector.match(prompt, pipeline_type)
+        for match in matches:
+            result.configs.append(match.lora)
+            result.auto_detected.append((match.lora.name, match.matched_trigger))
+
+    return result

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -1,12 +1,12 @@
-"""Tests for bot.py helper functions."""
+"""Tests for bot helper functions."""
 
 import pytest
 
-from oneiro.bot import (
+from oneiro.discord.commands import slugify
+from oneiro.services.generation import (
     MAX_LORA_WEIGHT,
     MIN_LORA_WEIGHT,
     parse_lora_param,
-    slugify,
     validate_lora_weight,
 )
 

--- a/tests/test_dream_params.py
+++ b/tests/test_dream_params.py
@@ -4,7 +4,7 @@ Tests for issue #51: Exposing steps and guidance_scale parameters in /dream comm
 and setting model defaults via /model command.
 """
 
-from oneiro.bot import (
+from oneiro.services.generation import (
     MAX_GUIDANCE_SCALE,
     MAX_STEPS,
     MIN_GUIDANCE_SCALE,


### PR DESCRIPTION
Split monolithic bot.py (850+ lines) into clean modular structure:

- services/generation.py: LoRA parsing, validation, resolution logic
- discord/handlers.py: DreamContext, callback factories, event handlers
- discord/commands.py: All 5 slash commands with register_commands()
- app.py: OneiroBot class + create_app() factory

Key changes:
- No backwards compatibility layer - imports use canonical locations
- Callback factory pattern for clean dependency injection
- Tests updated for new import paths