### PR TITLE
fix(deps): add protobuf requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
     "peft>=0.7.0",
     "gguf>=0.6.0",
     "kernels>=0.3.0",
+    "protobuf>=4.25.0",
     "httpx>=0.25.0",
 ]
 


### PR DESCRIPTION
Diffusers requires protobuf at runtime and fails to load models without it. Add protobuf to the base dependencies so container builds include it
 by default.