### PR TITLE
fix(deps): add sentencepiece

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
     "gguf>=0.6.0",
     "kernels>=0.3.0",
     "protobuf>=4.25.0",
+    "sentencepiece>=0.2.0",
     "httpx>=0.25.0",
 ]
 


### PR DESCRIPTION
Some tokenizers rely on sentencepiece for fast/slow conversions. Add it to base dependencies so model loading succeeds.