### PR TITLE
feat: add diffusers group offload

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -10,6 +10,9 @@ max_per_user = 20
 [models.zimage-turbo]
 type = "zimage"
 repo = "Tongyi-MAI/Z-Image-Turbo"
+cpu_offload = true
+offload_type = "group"          # "group" | "model" | "sequential"
+group_offload_type = "leaf_level"  # "leaf_level" minimizes VRAM; "block_level" lowers overhead
 steps = 9
 guidance_scale = 0.0
 
@@ -18,6 +21,8 @@ type = "flux2"
 repo = "diffusers/FLUX.2-dev-bnb-4bit"
 quantized = true
 cpu_offload = true
+offload_type = "group"          # "group" | "model" | "sequential"
+group_offload_type = "leaf_level"
 steps = 28
 guidance_scale = 4.0
 
@@ -28,6 +33,8 @@ transformer = "unsloth/Qwen-Image-GGUF:qwen-image-Q4_K_S.gguf"
 lora = "lightx2v/Qwen-Image-Lightning"
 lora_weights = "Qwen-Image-Lightning-8steps-V1.0.safetensors"
 cpu_offload = true
+offload_type = "group"          # Dedicated CivitAI Qwen checkpoints can still use sequential_cpu_offload
+group_offload_type = "leaf_level"
 steps = 8
 true_cfg_scale = 1.3
 requires_negative = true
@@ -242,10 +249,12 @@ verify_hashes = true
 # # component_repo = "Qwen/Qwen-Image"
 # # single_file_config_repo = "Qwen/Qwen-Image"
 # # transformer_subfolder = "transformer"
-# # Qwen transformer-only checkpoints can be very large; defaults use sequential CPU
-# # offload on CUDA while keeping transformer math in the device policy dtype.
+# # Qwen transformer-only checkpoints can be very large; by default they still use
+# # sequential CPU offload on CUDA unless offload_type is set explicitly.
 # # qwen_transformer_dtype = "bfloat16"     # Optional explicit override
-# # sequential_cpu_offload = true           # Set false to use model CPU offload instead
+# # sequential_cpu_offload = true           # Legacy toggle for the default Qwen behavior
+# # offload_type = "group"                  # Explicitly use group offload instead
+# # group_offload_type = "leaf_level"       # "leaf_level" | "block_level"
 #
 # Example 10: FLUX.2 Klein CivitAI checkpoint (transformer-only single file)
 # [models.flux2-klein-civitai]

--- a/scripts/benchmark_offload.py
+++ b/scripts/benchmark_offload.py
@@ -1,0 +1,245 @@
+"""Benchmark Diffusers offload modes for a configured Oneiro model.
+
+This script is intended for CUDA hosts. It reloads the same configured model with
+each requested offload mode, runs warmup + measured generations, and emits JSON
+with wall-clock latency plus CUDA peak memory metrics.
+"""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import json
+import statistics
+import time
+from copy import deepcopy
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+import torch
+
+from oneiro.config import Config
+from oneiro.device import DevicePolicy
+from oneiro.pipelines import PipelineManager
+
+DEFAULT_PROMPT = "a cinematic portrait of a robot blacksmith, dramatic light"
+DEFAULT_OFFLOAD_TYPES = ("model", "group")
+
+
+@dataclass
+class OffloadBenchmarkResult:
+    """Result for one offload mode benchmark run."""
+
+    model: str
+    pipeline_type: str
+    offload_type: str
+    status: str
+    load_seconds: float | None
+    warmup_runs: int
+    measured_runs: int
+    average_seconds: float | None
+    median_seconds: float | None
+    images_per_minute: float | None
+    load_peak_vram_mib: float | None
+    generation_peak_vram_mib: float | None
+    total_peak_vram_mib: float | None
+    error: str | None = None
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", default="config.toml", help="Path to base config.toml")
+    parser.add_argument("--overlay", default=None, help="Optional overlay config path")
+    parser.add_argument("--state", default=None, help="Optional runtime state JSON path")
+    parser.add_argument("--model", default=None, help="Configured model name to benchmark")
+    parser.add_argument(
+        "--offload-types",
+        nargs="+",
+        default=list(DEFAULT_OFFLOAD_TYPES),
+        choices=("model", "group", "sequential"),
+        help="Offload modes to compare. Defaults to old model offload vs new group offload.",
+    )
+    parser.add_argument("--prompt", default=DEFAULT_PROMPT, help="Prompt used for generation")
+    parser.add_argument("--negative-prompt", default=None, help="Optional negative prompt")
+    parser.add_argument("--width", type=int, default=None, help="Generation width override")
+    parser.add_argument("--height", type=int, default=None, help="Generation height override")
+    parser.add_argument("--steps", type=int, default=None, help="Inference steps override")
+    parser.add_argument("--guidance-scale", type=float, default=None, help="Guidance override")
+    parser.add_argument("--seed", type=int, default=12345, help="Base seed for measured runs")
+    parser.add_argument("--warmup-runs", type=int, default=1, help="Warmup generations per mode")
+    parser.add_argument("--runs", type=int, default=3, help="Measured generations per mode")
+    parser.add_argument("--output", default=None, help="Optional JSON output path")
+    return parser.parse_args()
+
+
+def clear_cuda() -> None:
+    """Release Python and CUDA memory before the next benchmark mode."""
+    gc.collect()
+    DevicePolicy.clear_cache()
+
+
+def peak_vram_mib() -> float:
+    """Return the current CUDA peak allocation in MiB."""
+    return torch.cuda.max_memory_allocated() / (1024 * 1024)
+
+
+def reset_peak_vram() -> None:
+    """Reset CUDA peak-memory accounting."""
+    torch.cuda.reset_peak_memory_stats()
+
+
+def load_config(args: argparse.Namespace) -> Config:
+    """Load Oneiro layered config from CLI arguments."""
+    config = Config(
+        base_path=Path(args.config),
+        overlay_path=Path(args.overlay) if args.overlay else None,
+        state_path=Path(args.state) if args.state else None,
+    )
+    config.load()
+    return config
+
+
+def resolve_model_config(config: Config, model_name: str | None) -> tuple[str, dict[str, Any]]:
+    """Return the selected model name and a mutable copy of its config."""
+    resolved_name = model_name or config.get("defaults", "model", default="zimage-turbo")
+    model_config = config.get("models", resolved_name)
+    if not isinstance(model_config, dict):
+        raise ValueError(f"Unknown model: {resolved_name}")
+    return resolved_name, deepcopy(model_config)
+
+
+def generation_kwargs(args: argparse.Namespace, model_config: dict[str, Any]) -> dict[str, Any]:
+    """Build generation kwargs from CLI overrides and model defaults."""
+    return {
+        "prompt": args.prompt,
+        "negative_prompt": args.negative_prompt,
+        "width": args.width or model_config.get("width", 1024),
+        "height": args.height or model_config.get("height", 1024),
+        "steps": args.steps or model_config.get("steps", 9),
+        "guidance_scale": args.guidance_scale
+        if args.guidance_scale is not None
+        else model_config.get("guidance_scale", model_config.get("true_cfg_scale", 0.0)),
+    }
+
+
+def run_generation_batch(
+    pipeline: Any,
+    args: argparse.Namespace,
+    model_config: dict[str, Any],
+    measured: bool,
+) -> list[float]:
+    """Run warmup or measured generations and return per-image durations."""
+    count = args.runs if measured else args.warmup_runs
+    durations: list[float] = []
+    kwargs = generation_kwargs(args, model_config)
+
+    for index in range(count):
+        started = time.perf_counter()
+        pipeline.generate(seed=args.seed + index, **kwargs)
+        torch.cuda.synchronize()
+        durations.append(time.perf_counter() - started)
+
+    return durations
+
+
+def benchmark_offload_type(
+    config: Config,
+    model_name: str,
+    base_model_config: dict[str, Any],
+    offload_type: str,
+    args: argparse.Namespace,
+) -> OffloadBenchmarkResult:
+    """Benchmark one offload mode for the selected model."""
+    model_config = deepcopy(base_model_config)
+    pipeline_type = model_config.get("type")
+    if not isinstance(pipeline_type, str) or pipeline_type not in PipelineManager.PIPELINE_TYPES:
+        raise ValueError(f"Unsupported pipeline type for {model_name}: {pipeline_type}")
+
+    model_config["cpu_offload"] = True
+    model_config["offload_type"] = offload_type
+
+    clear_cuda()
+    reset_peak_vram()
+    wrapper = PipelineManager.PIPELINE_TYPES[pipeline_type]()
+
+    load_started = time.perf_counter()
+    try:
+        wrapper.load(model_config, config.data)
+        torch.cuda.synchronize()
+        load_seconds = time.perf_counter() - load_started
+        load_peak = peak_vram_mib()
+
+        run_generation_batch(wrapper, args, model_config, measured=False)
+        reset_peak_vram()
+        durations = run_generation_batch(wrapper, args, model_config, measured=True)
+        generation_peak = peak_vram_mib()
+        average_seconds = statistics.mean(durations)
+        median_seconds = statistics.median(durations)
+        images_per_minute = 60 / average_seconds if average_seconds else None
+
+        return OffloadBenchmarkResult(
+            model=model_name,
+            pipeline_type=pipeline_type,
+            offload_type=offload_type,
+            status="ok",
+            load_seconds=load_seconds,
+            warmup_runs=args.warmup_runs,
+            measured_runs=args.runs,
+            average_seconds=average_seconds,
+            median_seconds=median_seconds,
+            images_per_minute=images_per_minute,
+            load_peak_vram_mib=load_peak,
+            generation_peak_vram_mib=generation_peak,
+            total_peak_vram_mib=max(load_peak, generation_peak),
+        )
+    except Exception as error:
+        return OffloadBenchmarkResult(
+            model=model_name,
+            pipeline_type=pipeline_type,
+            offload_type=offload_type,
+            status="error",
+            load_seconds=None,
+            warmup_runs=args.warmup_runs,
+            measured_runs=args.runs,
+            average_seconds=None,
+            median_seconds=None,
+            images_per_minute=None,
+            load_peak_vram_mib=None,
+            generation_peak_vram_mib=None,
+            total_peak_vram_mib=None,
+            error=f"{type(error).__name__}: {error}",
+        )
+    finally:
+        wrapper.unload()
+        clear_cuda()
+
+
+def write_results(results: list[OffloadBenchmarkResult], output: str | None) -> None:
+    """Write benchmark results to stdout and optionally to a JSON file."""
+    payload = [asdict(result) for result in results]
+    text = json.dumps(payload, indent=2)
+    print(text)
+    if output:
+        Path(output).write_text(text + "\n")
+
+
+def main() -> int:
+    """Run offload benchmarks for the selected model."""
+    args = parse_args()
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required for Diffusers CPU offload benchmarking")
+
+    config = load_config(args)
+    model_name, model_config = resolve_model_config(config, args.model)
+    results = [
+        benchmark_offload_type(config, model_name, model_config, offload_type, args)
+        for offload_type in args.offload_types
+    ]
+    write_results(results, args.output)
+    return 1 if any(result.status != "ok" for result in results) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/oneiro/device.py
+++ b/src/oneiro/device.py
@@ -14,6 +14,14 @@ class OffloadMode(StrEnum):
     NEVER = "never"  # Never offload, use .to(device)
 
 
+class OffloadType(StrEnum):
+    """Diffusers offload implementation to use when CPU offload is enabled."""
+
+    MODEL = "model"
+    GROUP = "group"
+    SEQUENTIAL = "sequential"
+
+
 @dataclass(frozen=True)
 class DevicePolicy:
     """Immutable device configuration for pipeline placement.
@@ -22,18 +30,37 @@ class DevicePolicy:
         device: Target device ("cuda", "mps", "cpu")
         dtype: Torch dtype for model weights
         offload: CPU offload behavior for large models
+        offload_type: Diffusers offload implementation to use when offloading
+        group_offload_type: Diffusers group-offload granularity
+        group_offload_use_stream: Overlap CPU/GPU transfers with CUDA streams
+        group_offload_num_blocks_per_group: Blocks per offload group for block-level mode
     """
 
     device: str
     dtype: torch.dtype
     offload: OffloadMode = OffloadMode.AUTO
+    offload_type: OffloadType = OffloadType.GROUP
+    group_offload_type: str = "leaf_level"
+    group_offload_use_stream: bool = True
+    group_offload_num_blocks_per_group: int | None = None
 
     @classmethod
-    def auto_detect(cls, cpu_offload: bool = True) -> "DevicePolicy":
+    def auto_detect(
+        cls,
+        cpu_offload: bool = True,
+        offload_type: str | OffloadType = OffloadType.GROUP,
+        group_offload_type: str = "leaf_level",
+        group_offload_use_stream: bool = True,
+        group_offload_num_blocks_per_group: int | None = None,
+    ) -> "DevicePolicy":
         """Create policy with auto-detected device and dtype.
 
         Args:
             cpu_offload: Enable CPU offloading when available (default: True)
+            offload_type: Offload implementation: "group", "model", or "sequential"
+            group_offload_type: Diffusers group-offload granularity
+            group_offload_use_stream: Overlap CPU/GPU transfers with CUDA streams
+            group_offload_num_blocks_per_group: Blocks per offload group for block-level mode
 
         Returns:
             DevicePolicy configured for the best available device
@@ -53,7 +80,15 @@ class DevicePolicy:
             dtype = torch.float32
 
         offload = OffloadMode.AUTO if cpu_offload else OffloadMode.NEVER
-        return cls(device=device, dtype=dtype, offload=offload)
+        return cls(
+            device=device,
+            dtype=dtype,
+            offload=offload,
+            offload_type=OffloadType(offload_type),
+            group_offload_type=group_offload_type,
+            group_offload_use_stream=group_offload_use_stream,
+            group_offload_num_blocks_per_group=group_offload_num_blocks_per_group,
+        )
 
     def apply_to_pipeline(self, pipe) -> None:
         """Apply device policy to a diffusers pipeline.
@@ -74,7 +109,27 @@ class DevicePolicy:
                     f"CPU offload requires CUDA device, got '{self.device}'. "
                     f"Set cpu_offload=false in config or use a CUDA-enabled system."
                 )
-            pipe.enable_model_cpu_offload()
+            if self.offload_type == OffloadType.MODEL:
+                pipe.enable_model_cpu_offload()
+                pipe._oneiro_offload_type = OffloadType.MODEL.value
+            elif self.offload_type == OffloadType.SEQUENTIAL:
+                pipe.enable_sequential_cpu_offload()
+                pipe._oneiro_offload_type = OffloadType.SEQUENTIAL.value
+            else:
+                group_offload_num_blocks_per_group = self.group_offload_num_blocks_per_group
+                if (
+                    self.group_offload_type == "block_level"
+                    and group_offload_num_blocks_per_group is None
+                ):
+                    group_offload_num_blocks_per_group = 1
+                pipe.enable_group_offload(
+                    onload_device=torch.device(self.device),
+                    offload_device=torch.device("cpu"),
+                    offload_type=self.group_offload_type,
+                    num_blocks_per_group=group_offload_num_blocks_per_group,
+                    use_stream=self.group_offload_use_stream,
+                )
+                pipe._oneiro_offload_type = OffloadType.GROUP.value
         elif self.device != "cpu":
             pipe.to(self.device)
         # CPU: no action needed, pipeline stays on CPU

--- a/src/oneiro/pipelines/base.py
+++ b/src/oneiro/pipelines/base.py
@@ -11,7 +11,7 @@ from typing import Any
 import torch
 from PIL import Image, UnidentifiedImageError
 
-from oneiro.device import DevicePolicy
+from oneiro.device import DevicePolicy, OffloadType
 
 MAX_INPUT_IMAGE_PIXELS = 4096 * 4096
 
@@ -215,6 +215,8 @@ class BasePipeline(ABC):
         This is the canonical way to reset diffusers pipeline state.
         """
         if self.pipe is None:
+            return
+        if getattr(self.pipe, "_oneiro_offload_type", None) == OffloadType.GROUP.value:
             return
         self.pipe.maybe_free_model_hooks()
 

--- a/src/oneiro/pipelines/civitai_checkpoint.py
+++ b/src/oneiro/pipelines/civitai_checkpoint.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING, Any
 import torch
 from PIL import Image
 
-from oneiro.device import DevicePolicy, OffloadMode
+from oneiro.device import DevicePolicy, OffloadMode, OffloadType
 from oneiro.pipelines.base import BasePipeline, GenerationResult
 from oneiro.pipelines.embedding import EmbeddingLoaderMixin, parse_embeddings_from_config
 from oneiro.pipelines.long_prompt import (
@@ -716,8 +716,24 @@ class CivitaiCheckpointPipeline(LoraLoaderMixin, EmbeddingLoaderMixin, BasePipel
         print(f"  Base model: {base_model or 'unknown'}")
         print(f"  Pipeline: {self._pipeline_config.pipeline_class}")
 
+        offload_type = model_config.get("offload_type")
+        if (
+            offload_type is None
+            and self._pipeline_config.pipeline_class == "QwenImagePipeline"
+            and model_config.get("sequential_cpu_offload") is False
+        ):
+            offload_type = OffloadType.MODEL.value
+
         cpu_offload = model_config.get("cpu_offload", True)
-        self.policy = DevicePolicy.auto_detect(cpu_offload=cpu_offload)
+        self.policy = DevicePolicy.auto_detect(
+            cpu_offload=cpu_offload,
+            offload_type=offload_type or "group",
+            group_offload_type=model_config.get("group_offload_type", "leaf_level"),
+            group_offload_use_stream=model_config.get("group_offload_use_stream", True),
+            group_offload_num_blocks_per_group=model_config.get(
+                "group_offload_num_blocks_per_group"
+            ),
+        )
 
         # Get the pipeline class unless this wrapper has a custom assembly path.
         pipeline_class: type | None = None
@@ -740,15 +756,6 @@ class CivitaiCheckpointPipeline(LoraLoaderMixin, EmbeddingLoaderMixin, BasePipel
         scheduler_override = model_config.get("scheduler")
         self.configure_scheduler(scheduler_override)
 
-        if self._should_use_sequential_cpu_offload(model_config):
-            self.pipe.enable_sequential_cpu_offload()
-        else:
-            self.policy.apply_to_pipeline(self.pipe)
-        # Track whether offload was applied (for dynamic LoRA handling)
-        self._cpu_offload = (
-            self.policy.offload != OffloadMode.NEVER and self.policy.device == "cuda"
-        )
-
         # Enable memory optimizations for VAE if available
         if hasattr(self.pipe, "vae"):
             if hasattr(self.pipe.vae, "enable_tiling"):
@@ -770,6 +777,16 @@ class CivitaiCheckpointPipeline(LoraLoaderMixin, EmbeddingLoaderMixin, BasePipel
             if embeddings:
                 print(f"  Loading {len(embeddings)} embedding(s)...")
                 self.load_embeddings_sync(embeddings)
+
+        if self._should_use_sequential_cpu_offload(model_config):
+            self.pipe.enable_sequential_cpu_offload()
+            self.pipe._oneiro_offload_type = OffloadType.SEQUENTIAL.value
+        else:
+            self.policy.apply_to_pipeline(self.pipe)
+        # Track whether offload was applied (for dynamic LoRA handling)
+        self._cpu_offload = (
+            self.policy.offload != OffloadMode.NEVER and self.policy.device == "cuda"
+        )
 
         print(f"Checkpoint loaded: {checkpoint_path.name}")
 
@@ -961,6 +978,10 @@ class CivitaiCheckpointPipeline(LoraLoaderMixin, EmbeddingLoaderMixin, BasePipel
         should_offload = self.policy.offload != OffloadMode.NEVER and self.policy.device == "cuda"
         if not should_offload:
             return False
+
+        offload_type = model_config.get("offload_type")
+        if offload_type is not None:
+            return OffloadType(offload_type) == OffloadType.SEQUENTIAL
 
         configured = model_config.get("sequential_cpu_offload")
         if configured is not None:

--- a/src/oneiro/pipelines/flux1.py
+++ b/src/oneiro/pipelines/flux1.py
@@ -29,13 +29,14 @@ class Flux1PipelineWrapper(BasePipeline):
     - FLUX.1-schnell: Fast 4-step generation (steps=4, guidance_scale=0.0)
     """
 
-    def load(self, model_config: dict[str, Any]) -> None:
+    def load(self, model_config: dict[str, Any], full_config: dict[str, Any] | None = None) -> None:
         """Load FLUX.1 model with optional CPU offloading and LoRA support.
 
         Args:
             model_config: Configuration dict with keys:
                 - repo: HuggingFace repo ID (default: "black-forest-labs/FLUX.1-dev")
                 - cpu_offload: Enable CPU offloading (default: True)
+                - offload_type: Offload implementation: group, model, or sequential
                 - cpu_utilization: Fraction of CPU cores to use (default: 0.75)
                 - lora: LoRA repository ID (optional)
                 - lora_weights: LoRA weights filename (optional, required if lora is set)
@@ -44,6 +45,10 @@ class Flux1PipelineWrapper(BasePipeline):
 
         repo = model_config.get("repo", "black-forest-labs/FLUX.1-dev")
         cpu_offload = model_config.get("cpu_offload", True)
+        offload_type = model_config.get("offload_type", "group")
+        group_offload_type = model_config.get("group_offload_type", "leaf_level")
+        group_offload_use_stream = model_config.get("group_offload_use_stream", True)
+        group_offload_num_blocks_per_group = model_config.get("group_offload_num_blocks_per_group")
         cpu_utilization = model_config.get("cpu_utilization", 0.75)
 
         print(f"Loading FLUX.1 from {repo}")
@@ -51,15 +56,19 @@ class Flux1PipelineWrapper(BasePipeline):
         # Configure CPU threading for text encoder
         self._configure_cpu_threads(cpu_utilization)
 
-        self.policy = DevicePolicy.auto_detect(cpu_offload=cpu_offload)
+        self.policy = DevicePolicy.auto_detect(
+            cpu_offload=cpu_offload,
+            offload_type=offload_type,
+            group_offload_type=group_offload_type,
+            group_offload_use_stream=group_offload_use_stream,
+            group_offload_num_blocks_per_group=group_offload_num_blocks_per_group,
+        )
 
         print("  Creating pipeline...")
         self.pipe = FluxPipeline.from_pretrained(
             repo,
             torch_dtype=self.policy.dtype,
         )
-
-        self.policy.apply_to_pipeline(self.pipe)
 
         # Memory optimization for large T5 encoder and high-res VAE decoding
         self.pipe.vae.enable_tiling()
@@ -72,6 +81,8 @@ class Flux1PipelineWrapper(BasePipeline):
         if lora_repo and lora_weights:
             print(f"Loading LoRA from {lora_repo}")
             self.pipe.load_lora_weights(lora_repo, weight_name=lora_weights)
+
+        self.policy.apply_to_pipeline(self.pipe)
 
         print(f"FLUX.1 loaded from {repo}")
 

--- a/src/oneiro/pipelines/flux2.py
+++ b/src/oneiro/pipelines/flux2.py
@@ -24,6 +24,10 @@ class Flux2PipelineWrapper(LoraLoaderMixin, EmbeddingLoaderMixin, BasePipeline):
 
         repo = model_config.get("repo", "diffusers/FLUX.2-dev-bnb-4bit")
         cpu_offload = model_config.get("cpu_offload", True)
+        offload_type = model_config.get("offload_type", "group")
+        group_offload_type = model_config.get("group_offload_type", "leaf_level")
+        group_offload_use_stream = model_config.get("group_offload_use_stream", True)
+        group_offload_num_blocks_per_group = model_config.get("group_offload_num_blocks_per_group")
         cpu_utilization = model_config.get("cpu_utilization", 0.75)
 
         print(f"Loading FLUX.2 from {repo}")
@@ -31,7 +35,13 @@ class Flux2PipelineWrapper(LoraLoaderMixin, EmbeddingLoaderMixin, BasePipeline):
         # Configure CPU threading for text encoder
         self._configure_cpu_threads(cpu_utilization)
 
-        self.policy = DevicePolicy.auto_detect(cpu_offload=cpu_offload)
+        self.policy = DevicePolicy.auto_detect(
+            cpu_offload=cpu_offload,
+            offload_type=offload_type,
+            group_offload_type=group_offload_type,
+            group_offload_use_stream=group_offload_use_stream,
+            group_offload_num_blocks_per_group=group_offload_num_blocks_per_group,
+        )
 
         # Load transformer and text encoder on CPU first
         print("  Loading transformer on CPU...")
@@ -39,7 +49,6 @@ class Flux2PipelineWrapper(LoraLoaderMixin, EmbeddingLoaderMixin, BasePipeline):
             repo,
             subfolder="transformer",
             torch_dtype=self.policy.dtype,
-            device_map="cpu",
         )
 
         print("  Loading text encoder on CPU...")
@@ -47,7 +56,6 @@ class Flux2PipelineWrapper(LoraLoaderMixin, EmbeddingLoaderMixin, BasePipeline):
             repo,
             subfolder="text_encoder",
             torch_dtype=self.policy.dtype,
-            device_map="cpu",
         )
 
         print("  Creating pipeline...")
@@ -57,8 +65,6 @@ class Flux2PipelineWrapper(LoraLoaderMixin, EmbeddingLoaderMixin, BasePipeline):
             text_encoder=text_encoder,
             torch_dtype=self.policy.dtype,
         )
-
-        self.policy.apply_to_pipeline(self.pipe)
 
         loras = parse_loras_from_model_config(model_config)
         if loras:
@@ -72,6 +78,8 @@ class Flux2PipelineWrapper(LoraLoaderMixin, EmbeddingLoaderMixin, BasePipeline):
             if embeddings:
                 print(f"  Loading {len(embeddings)} embedding(s)...")
                 self.load_embeddings_sync(embeddings)
+
+        self.policy.apply_to_pipeline(self.pipe)
 
         print(f"FLUX.2 loaded from {repo}")
 

--- a/src/oneiro/pipelines/qwen.py
+++ b/src/oneiro/pipelines/qwen.py
@@ -96,14 +96,25 @@ class QwenPipelineWrapper(LoraLoaderMixin, EmbeddingLoaderMixin, BasePipeline):
             lora: LoRA repository
             lora_weights: LoRA weights filename
             cpu_offload: Enable CPU offload (default: True)
+            offload_type: Offload implementation: group, model, or sequential
         """
         from diffusers import DiffusionPipeline, FlowMatchEulerDiscreteScheduler
 
         repo = model_config.get("repo", "Qwen/Qwen-Image")
         transformer_path = model_config.get("transformer")
         cpu_offload = model_config.get("cpu_offload", True)
+        offload_type = model_config.get("offload_type", "group")
+        group_offload_type = model_config.get("group_offload_type", "leaf_level")
+        group_offload_use_stream = model_config.get("group_offload_use_stream", True)
+        group_offload_num_blocks_per_group = model_config.get("group_offload_num_blocks_per_group")
 
-        self.policy = DevicePolicy.auto_detect(cpu_offload=cpu_offload)
+        self.policy = DevicePolicy.auto_detect(
+            cpu_offload=cpu_offload,
+            offload_type=offload_type,
+            group_offload_type=group_offload_type,
+            group_offload_use_stream=group_offload_use_stream,
+            group_offload_num_blocks_per_group=group_offload_num_blocks_per_group,
+        )
 
         print(f"Loading Qwen-Image from {repo}")
 
@@ -140,8 +151,6 @@ class QwenPipelineWrapper(LoraLoaderMixin, EmbeddingLoaderMixin, BasePipeline):
 
         self.pipe = DiffusionPipeline.from_pretrained(repo, **pipeline_kwargs)
 
-        self.policy.apply_to_pipeline(self.pipe)
-
         loras = parse_loras_from_model_config(model_config)
         if loras:
             print(f"  Loading {len(loras)} LoRA(s)...")
@@ -153,6 +162,8 @@ class QwenPipelineWrapper(LoraLoaderMixin, EmbeddingLoaderMixin, BasePipeline):
             if embeddings:
                 print(f"  Loading {len(embeddings)} embedding(s)...")
                 self.load_embeddings_sync(embeddings)
+
+        self.policy.apply_to_pipeline(self.pipe)
 
         print(f"Qwen-Image loaded from {repo}")
 

--- a/src/oneiro/pipelines/zimage.py
+++ b/src/oneiro/pipelines/zimage.py
@@ -5,7 +5,7 @@ from typing import Any
 import torch
 from PIL import Image
 
-from oneiro.device import DevicePolicy
+from oneiro.device import DevicePolicy, OffloadType
 from oneiro.pipelines.base import BasePipeline, GenerationResult
 from oneiro.pipelines.embedding import EmbeddingLoaderMixin, parse_embeddings_from_config
 from oneiro.pipelines.lora import LoraLoaderMixin, parse_loras_from_model_config
@@ -28,8 +28,18 @@ class ZImagePipelineWrapper(LoraLoaderMixin, EmbeddingLoaderMixin, BasePipeline)
 
         repo = model_config.get("repo", "Tongyi-MAI/Z-Image-Turbo")
         cpu_offload = model_config.get("cpu_offload", True)
+        offload_type = model_config.get("offload_type", "group")
+        group_offload_type = model_config.get("group_offload_type", "leaf_level")
+        group_offload_use_stream = model_config.get("group_offload_use_stream", True)
+        group_offload_num_blocks_per_group = model_config.get("group_offload_num_blocks_per_group")
 
-        self.policy = DevicePolicy.auto_detect(cpu_offload=cpu_offload)
+        self.policy = DevicePolicy.auto_detect(
+            cpu_offload=cpu_offload,
+            offload_type=offload_type,
+            group_offload_type=group_offload_type,
+            group_offload_use_stream=group_offload_use_stream,
+            group_offload_num_blocks_per_group=group_offload_num_blocks_per_group,
+        )
 
         print(f"Loading Z-Image from {repo}")
 
@@ -40,8 +50,6 @@ class ZImagePipelineWrapper(LoraLoaderMixin, EmbeddingLoaderMixin, BasePipeline)
         self.img2img_pipe = ZImageImg2ImgPipeline(**self.pipe.components)
         self.inpaint_pipe = ZImageInpaintPipeline(**self.pipe.components)
         self._active_pipe = self.pipe
-
-        self.policy.apply_to_pipeline(self.pipe)
 
         loras = parse_loras_from_model_config(model_config)
         if loras:
@@ -55,6 +63,8 @@ class ZImagePipelineWrapper(LoraLoaderMixin, EmbeddingLoaderMixin, BasePipeline)
             if embeddings:
                 print(f"  Loading {len(embeddings)} embedding(s)...")
                 self.load_embeddings_sync(embeddings)
+
+        self.policy.apply_to_pipeline(self.pipe)
 
         print(f"Z-Image loaded from {repo}")
 
@@ -152,6 +162,10 @@ class ZImagePipelineWrapper(LoraLoaderMixin, EmbeddingLoaderMixin, BasePipeline)
 
     def _reset_model_state(self) -> None:
         """Reset hooks on the Z-Image pipeline variant used for this generation."""
+        if self.pipe is not None and getattr(self.pipe, "_oneiro_offload_type", None) == (
+            OffloadType.GROUP.value
+        ):
+            return
         if self._active_pipe is None:
             return
         self._active_pipe.maybe_free_model_hooks()

--- a/tests/test_civitai_checkpoint.py
+++ b/tests/test_civitai_checkpoint.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 import torch
 
-from oneiro.device import DevicePolicy, OffloadMode
+from oneiro.device import DevicePolicy, OffloadMode, OffloadType
 from oneiro.pipelines.civitai_checkpoint import (
     CIVITAI_BASE_MODEL_PIPELINE_MAP,
     DEFAULT_PIPELINE_CONFIG,
@@ -362,8 +362,8 @@ class TestCivitaiCheckpointPipelineLoad:
 
     @patch.object(CivitaiCheckpointPipeline, "configure_scheduler")
     @patch("oneiro.pipelines.civitai_checkpoint.get_diffusers_pipeline_class")
-    def test_load_enables_cpu_offload(self, mock_get_class, mock_config_sched, tmp_path):
-        """load() enables CPU offload when configured on CUDA."""
+    def test_load_enables_group_offload(self, mock_get_class, mock_config_sched, tmp_path):
+        """load() enables group offload when configured on CUDA."""
         checkpoint = tmp_path / "model.safetensors"
         checkpoint.write_bytes(b"dummy")
 
@@ -380,6 +380,36 @@ class TestCivitaiCheckpointPipelineLoad:
                 {
                     "checkpoint_path": str(checkpoint),
                     "cpu_offload": True,
+                }
+            )
+
+        mock_pipe.enable_group_offload.assert_called_once()
+
+    @patch.object(CivitaiCheckpointPipeline, "configure_scheduler")
+    @patch("oneiro.pipelines.civitai_checkpoint.get_diffusers_pipeline_class")
+    def test_load_can_use_model_cpu_offload(self, mock_get_class, mock_config_sched, tmp_path):
+        """load() can use legacy model CPU offload when requested."""
+        checkpoint = tmp_path / "model.safetensors"
+        checkpoint.write_bytes(b"dummy")
+
+        mock_pipeline_class = MagicMock()
+        mock_pipe = MagicMock()
+        mock_pipeline_class.from_single_file.return_value = mock_pipe
+        mock_get_class.return_value = mock_pipeline_class
+
+        pipeline = CivitaiCheckpointPipeline()
+        mock_policy = DevicePolicy(
+            device="cuda",
+            dtype=torch.float16,
+            offload=OffloadMode.AUTO,
+            offload_type="model",
+        )
+        with patch.object(DevicePolicy, "auto_detect", return_value=mock_policy):
+            pipeline.load(
+                {
+                    "checkpoint_path": str(checkpoint),
+                    "cpu_offload": True,
+                    "offload_type": "model",
                 }
             )
 
@@ -776,7 +806,93 @@ class TestCivitaiCheckpointPipelineLoad:
             )
 
         mock_pipe.enable_sequential_cpu_offload.assert_called_once_with()
+        assert mock_pipe._oneiro_offload_type == "sequential"
         mock_apply_to_pipeline.assert_not_called()
+
+    def test_load_qwen_can_use_explicit_group_offload_on_cuda(self, tmp_path):
+        """Qwen CivitAI checkpoints can opt into group offload explicitly."""
+        checkpoint = tmp_path / "qwen.safetensors"
+        checkpoint.write_bytes(b"dummy")
+
+        mock_pipe = MagicMock()
+        mock_transformer = MagicMock()
+        mock_scheduler = MagicMock()
+        qwen_state_dict = {"img_in.weight": MagicMock()}
+        mock_policy = DevicePolicy(device="cuda", dtype=torch.float16, offload=OffloadMode.AUTO)
+
+        with (
+            patch.object(CivitaiCheckpointPipeline, "configure_scheduler"),
+            patch.object(DevicePolicy, "auto_detect", return_value=mock_policy),
+            patch.object(DevicePolicy, "apply_to_pipeline") as mock_apply_to_pipeline,
+            patch.object(
+                CivitaiCheckpointPipeline,
+                "_load_transformer_checkpoint",
+                return_value=qwen_state_dict,
+            ),
+            patch("diffusers.QwenImageTransformer2DModel") as mock_transformer_class,
+            patch("diffusers.FlowMatchEulerDiscreteScheduler") as mock_scheduler_class,
+            patch("diffusers.DiffusionPipeline") as mock_diffusion_pipeline,
+        ):
+            mock_transformer_class.from_single_file.return_value = mock_transformer
+            mock_scheduler_class.from_config.return_value = mock_scheduler
+            mock_diffusion_pipeline.from_pretrained.return_value = mock_pipe
+
+            pipeline = CivitaiCheckpointPipeline()
+            pipeline.load(
+                {
+                    "checkpoint_path": str(checkpoint),
+                    "base_model": "Qwen",
+                    "offload_type": "group",
+                }
+            )
+
+        mock_pipe.enable_sequential_cpu_offload.assert_not_called()
+        mock_apply_to_pipeline.assert_called_once_with(mock_pipe)
+
+    def test_load_qwen_sequential_false_uses_model_offload_on_cuda(self, tmp_path):
+        """Legacy sequential_cpu_offload=False keeps model offload for Qwen checkpoints."""
+        checkpoint = tmp_path / "qwen.safetensors"
+        checkpoint.write_bytes(b"dummy")
+
+        mock_pipe = MagicMock()
+        mock_transformer = MagicMock()
+        mock_scheduler = MagicMock()
+        qwen_state_dict = {"img_in.weight": MagicMock()}
+        mock_policy = DevicePolicy(
+            device="cuda",
+            dtype=torch.float16,
+            offload=OffloadMode.AUTO,
+            offload_type=OffloadType.MODEL,
+        )
+
+        with (
+            patch.object(CivitaiCheckpointPipeline, "configure_scheduler"),
+            patch.object(DevicePolicy, "auto_detect", return_value=mock_policy) as mock_auto_detect,
+            patch.object(
+                CivitaiCheckpointPipeline,
+                "_load_transformer_checkpoint",
+                return_value=qwen_state_dict,
+            ),
+            patch("diffusers.QwenImageTransformer2DModel") as mock_transformer_class,
+            patch("diffusers.FlowMatchEulerDiscreteScheduler") as mock_scheduler_class,
+            patch("diffusers.DiffusionPipeline") as mock_diffusion_pipeline,
+        ):
+            mock_transformer_class.from_single_file.return_value = mock_transformer
+            mock_scheduler_class.from_config.return_value = mock_scheduler
+            mock_diffusion_pipeline.from_pretrained.return_value = mock_pipe
+
+            pipeline = CivitaiCheckpointPipeline()
+            pipeline.load(
+                {
+                    "checkpoint_path": str(checkpoint),
+                    "base_model": "Qwen",
+                    "sequential_cpu_offload": False,
+                }
+            )
+
+        assert mock_auto_detect.call_args.kwargs["offload_type"] == "model"
+        mock_pipe.enable_sequential_cpu_offload.assert_not_called()
+        mock_pipe.enable_model_cpu_offload.assert_called_once_with()
 
     def test_load_flux2_klein_single_file_assembles_klein_pipeline(self, tmp_path):
         """CivitAI FLUX.2 Klein checkpoints load via the Flux2 transformer path."""

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -3,7 +3,7 @@
 import pytest
 import torch
 
-from oneiro.device import DevicePolicy, OffloadMode
+from oneiro.device import DevicePolicy, OffloadMode, OffloadType
 
 
 class TestOffloadMode:
@@ -18,6 +18,20 @@ class TestOffloadMode:
         """OffloadMode should be usable as a string."""
         assert isinstance(OffloadMode.AUTO, str)
         assert OffloadMode.AUTO == "auto"
+
+
+class TestOffloadType:
+    """Tests for OffloadType enum."""
+
+    def test_string_values(self):
+        assert OffloadType.MODEL.value == "model"
+        assert OffloadType.GROUP.value == "group"
+        assert OffloadType.SEQUENTIAL.value == "sequential"
+
+    def test_is_str_subclass(self):
+        """OffloadType should be usable as a string."""
+        assert isinstance(OffloadType.GROUP, str)
+        assert OffloadType.GROUP == "group"
 
 
 class TestDevicePolicyAutoDetect:
@@ -35,6 +49,16 @@ class TestDevicePolicyAutoDetect:
     def test_cpu_offload_false_sets_never(self):
         policy = DevicePolicy.auto_detect(cpu_offload=False)
         assert policy.offload == OffloadMode.NEVER
+
+    def test_auto_detect_defaults_to_group_offload(self):
+        policy = DevicePolicy.auto_detect()
+        assert policy.offload_type == OffloadType.GROUP
+        assert policy.group_offload_type == "leaf_level"
+        assert policy.group_offload_use_stream is True
+
+    def test_auto_detect_accepts_model_offload_type(self):
+        policy = DevicePolicy.auto_detect(offload_type="model")
+        assert policy.offload_type == OffloadType.MODEL
 
     def test_dtype_is_valid_torch_dtype(self):
         policy = DevicePolicy.auto_detect()
@@ -64,6 +88,11 @@ class TestDevicePolicyFrozen:
         policy = DevicePolicy.auto_detect()
         with pytest.raises(AttributeError):
             policy.offload = OffloadMode.NEVER
+
+    def test_cannot_modify_offload_type(self):
+        policy = DevicePolicy.auto_detect()
+        with pytest.raises(AttributeError):
+            policy.offload_type = OffloadType.MODEL
 
 
 class TestDevicePolicyApply:
@@ -101,12 +130,40 @@ class TestDevicePolicyApply:
         policy.apply_to_pipeline(pipe)
         assert pipe.moved_to == "cuda"
 
-    def test_auto_offload_on_cuda_enables_offload(self):
+    def test_auto_group_offload_on_cuda_enables_group_offload(self):
         policy = DevicePolicy(device="cuda", dtype=torch.float16, offload=OffloadMode.AUTO)
 
         class MockPipeline:
             def __init__(self):
+                self.group_offload_kwargs = None
+                self._oneiro_offload_type: str | None = None
+
+            def enable_group_offload(self, **kwargs):
+                self.group_offload_kwargs = kwargs
+
+        pipe = MockPipeline()
+        policy.apply_to_pipeline(pipe)
+        assert pipe.group_offload_kwargs == {
+            "onload_device": torch.device("cuda"),
+            "offload_device": torch.device("cpu"),
+            "offload_type": "leaf_level",
+            "num_blocks_per_group": None,
+            "use_stream": True,
+        }
+        assert pipe._oneiro_offload_type == "group"
+
+    def test_model_offload_on_cuda_enables_model_offload(self):
+        policy = DevicePolicy(
+            device="cuda",
+            dtype=torch.float16,
+            offload=OffloadMode.AUTO,
+            offload_type=OffloadType.MODEL,
+        )
+
+        class MockPipeline:
+            def __init__(self):
                 self.offload_enabled = False
+                self._oneiro_offload_type: str | None = None
 
             def enable_model_cpu_offload(self):
                 self.offload_enabled = True
@@ -114,6 +171,70 @@ class TestDevicePolicyApply:
         pipe = MockPipeline()
         policy.apply_to_pipeline(pipe)
         assert pipe.offload_enabled is True
+        assert pipe._oneiro_offload_type == "model"
+
+    def test_sequential_offload_on_cuda_enables_sequential_offload(self):
+        policy = DevicePolicy(
+            device="cuda",
+            dtype=torch.float16,
+            offload=OffloadMode.AUTO,
+            offload_type=OffloadType.SEQUENTIAL,
+        )
+
+        class MockPipeline:
+            def __init__(self):
+                self.offload_enabled = False
+                self._oneiro_offload_type: str | None = None
+
+            def enable_sequential_cpu_offload(self):
+                self.offload_enabled = True
+
+        pipe = MockPipeline()
+        policy.apply_to_pipeline(pipe)
+        assert pipe.offload_enabled is True
+        assert pipe._oneiro_offload_type == "sequential"
+
+    def test_block_level_stream_defaults_to_one_block_per_group(self):
+        policy = DevicePolicy(
+            device="cuda",
+            dtype=torch.float16,
+            offload=OffloadMode.AUTO,
+            group_offload_type="block_level",
+        )
+
+        class MockPipeline:
+            def __init__(self):
+                self.group_offload_kwargs = None
+
+            def enable_group_offload(self, **kwargs):
+                self.group_offload_kwargs = kwargs
+
+        pipe = MockPipeline()
+        policy.apply_to_pipeline(pipe)
+        assert pipe.group_offload_kwargs is not None
+        assert pipe.group_offload_kwargs["num_blocks_per_group"] == 1
+
+    def test_block_level_without_stream_defaults_to_one_block_per_group(self):
+        policy = DevicePolicy(
+            device="cuda",
+            dtype=torch.float16,
+            offload=OffloadMode.AUTO,
+            group_offload_type="block_level",
+            group_offload_use_stream=False,
+        )
+
+        class MockPipeline:
+            def __init__(self):
+                self.group_offload_kwargs = None
+
+            def enable_group_offload(self, **kwargs):
+                self.group_offload_kwargs = kwargs
+
+        pipe = MockPipeline()
+        policy.apply_to_pipeline(pipe)
+        assert pipe.group_offload_kwargs is not None
+        assert pipe.group_offload_kwargs["num_blocks_per_group"] == 1
+        assert pipe.group_offload_kwargs["use_stream"] is False
 
     def test_auto_offload_on_cpu_no_action(self):
         policy = DevicePolicy(device="cpu", dtype=torch.float32, offload=OffloadMode.AUTO)

--- a/tests/test_pipelines_base.py
+++ b/tests/test_pipelines_base.py
@@ -8,7 +8,7 @@ import pytest
 import torch
 from PIL import Image
 
-from oneiro.device import DevicePolicy, OffloadMode
+from oneiro.device import DevicePolicy, OffloadMode, OffloadType
 from oneiro.pipelines import PipelineManager
 from oneiro.pipelines.base import BasePipeline, GenerationResult
 from oneiro.pipelines.lora import LoraConfig, LoraSource
@@ -323,6 +323,16 @@ class TestBasePipelinePostGenerate:
         pipeline.pipe = mock_pipe
         pipeline._reset_model_state()
         mock_pipe.maybe_free_model_hooks.assert_called_once()
+
+    @patch("oneiro.pipelines.base.torch.cuda.is_available", return_value=False)
+    def test_reset_model_state_skips_group_offload_pipelines(self, mock_cuda):
+        """_reset_model_state() skips model hook reset for group offload."""
+        pipeline = ConcretePipeline()
+        mock_pipe = Mock()
+        mock_pipe._oneiro_offload_type = OffloadType.GROUP.value
+        pipeline.pipe = mock_pipe
+        pipeline._reset_model_state()
+        mock_pipe.maybe_free_model_hooks.assert_not_called()
 
     @patch("oneiro.pipelines.base.torch.cuda.is_available", return_value=False)
     def test_reset_model_state_handles_none_pipe(self, mock_cuda):

--- a/tests/test_pipelines_flux1.py
+++ b/tests/test_pipelines_flux1.py
@@ -57,8 +57,10 @@ class TestFlux1PipelineWrapperLoad:
     @patch("oneiro.pipelines.base.torch.set_num_interop_threads")
     @patch("oneiro.pipelines.base.torch.set_num_threads")
     @patch("diffusers.FluxPipeline")
-    def test_load_enables_cpu_offload_on_cuda(self, mock_flux_pipeline, mock_threads, mock_interop):
-        """Load enables CPU offload on CUDA by default."""
+    def test_load_enables_group_offload_on_cuda(
+        self, mock_flux_pipeline, mock_threads, mock_interop
+    ):
+        """Load enables group offload on CUDA by default."""
         mock_pipe = MagicMock()
         mock_flux_pipeline.from_pretrained.return_value = mock_pipe
 
@@ -68,7 +70,7 @@ class TestFlux1PipelineWrapperLoad:
             pipeline = Flux1PipelineWrapper()
             pipeline.load({})
 
-        mock_pipe.enable_model_cpu_offload.assert_called_once()
+        mock_pipe.enable_group_offload.assert_called_once()
 
     @patch("oneiro.pipelines.base.torch.set_num_interop_threads")
     @patch("oneiro.pipelines.base.torch.set_num_threads")
@@ -83,6 +85,7 @@ class TestFlux1PipelineWrapperLoad:
         pipeline = Flux1PipelineWrapper()
         pipeline.load({"cpu_offload": False})
 
+        mock_pipe.enable_group_offload.assert_not_called()
         mock_pipe.enable_model_cpu_offload.assert_not_called()
 
     @patch("oneiro.pipelines.base.torch.set_num_interop_threads")

--- a/tests/test_pipelines_flux2.py
+++ b/tests/test_pipelines_flux2.py
@@ -46,6 +46,11 @@ class TestFlux2PipelineWrapperLoad:
         call_args = mock_flux2_pipeline.from_pretrained.call_args
         assert call_args[0][0] == "diffusers/FLUX.2-dev-bnb-4bit"
 
+        transformer_kwargs = mock_transformer.from_pretrained.call_args.kwargs
+        text_encoder_kwargs = mock_text_encoder.from_pretrained.call_args.kwargs
+        assert "device_map" not in transformer_kwargs
+        assert "device_map" not in text_encoder_kwargs
+
     @patch("oneiro.pipelines.base.torch.set_num_interop_threads")
     @patch("oneiro.pipelines.base.torch.set_num_threads")
     @patch("transformers.Mistral3ForConditionalGeneration")
@@ -71,10 +76,10 @@ class TestFlux2PipelineWrapperLoad:
     @patch("transformers.Mistral3ForConditionalGeneration")
     @patch("diffusers.Flux2Transformer2DModel")
     @patch("diffusers.Flux2Pipeline")
-    def test_load_enables_cpu_offload_on_cuda(
+    def test_load_enables_group_offload_on_cuda(
         self, mock_flux2_pipeline, mock_transformer, mock_text_encoder, mock_threads, mock_interop
     ):
-        """Load enables CPU offload on CUDA by default."""
+        """Load enables group offload on CUDA by default."""
         mock_pipe = MagicMock()
         mock_flux2_pipeline.from_pretrained.return_value = mock_pipe
         mock_transformer.from_pretrained.return_value = MagicMock()
@@ -86,7 +91,7 @@ class TestFlux2PipelineWrapperLoad:
             pipeline = Flux2PipelineWrapper()
             pipeline.load({})
 
-        mock_pipe.enable_model_cpu_offload.assert_called_once()
+        mock_pipe.enable_group_offload.assert_called_once()
 
     @patch("oneiro.pipelines.base.torch.set_num_interop_threads")
     @patch("oneiro.pipelines.base.torch.set_num_threads")
@@ -105,6 +110,7 @@ class TestFlux2PipelineWrapperLoad:
         pipeline = Flux2PipelineWrapper()
         pipeline.load({"cpu_offload": False})
 
+        mock_pipe.enable_group_offload.assert_not_called()
         mock_pipe.enable_model_cpu_offload.assert_not_called()
 
 

--- a/tests/test_pipelines_qwen.py
+++ b/tests/test_pipelines_qwen.py
@@ -105,8 +105,8 @@ class TestQwenPipelineWrapperLoad:
 
     @patch("diffusers.FlowMatchEulerDiscreteScheduler")
     @patch("diffusers.DiffusionPipeline")
-    def test_load_enables_cpu_offload_on_cuda(self, mock_diffusion_pipeline, mock_scheduler):
-        """Load enables CPU offload on CUDA by default."""
+    def test_load_enables_group_offload_on_cuda(self, mock_diffusion_pipeline, mock_scheduler):
+        """Load enables group offload on CUDA by default."""
         mock_pipe = MagicMock()
         mock_diffusion_pipeline.from_pretrained.return_value = mock_pipe
         mock_scheduler.from_config.return_value = MagicMock()
@@ -117,7 +117,7 @@ class TestQwenPipelineWrapperLoad:
             pipeline = QwenPipelineWrapper()
             pipeline.load({})
 
-        mock_pipe.enable_model_cpu_offload.assert_called_once()
+        mock_pipe.enable_group_offload.assert_called_once()
 
     @patch("diffusers.FlowMatchEulerDiscreteScheduler")
     @patch("diffusers.DiffusionPipeline")
@@ -132,6 +132,7 @@ class TestQwenPipelineWrapperLoad:
         pipeline = QwenPipelineWrapper()
         pipeline.load({"cpu_offload": False})
 
+        mock_pipe.enable_group_offload.assert_not_called()
         mock_pipe.enable_model_cpu_offload.assert_not_called()
 
 

--- a/tests/test_pipelines_zimage.py
+++ b/tests/test_pipelines_zimage.py
@@ -88,10 +88,10 @@ class TestZImagePipelineWrapperLoad:
     @patch("diffusers.ZImageInpaintPipeline")
     @patch("diffusers.ZImageImg2ImgPipeline")
     @patch("diffusers.ZImagePipeline")
-    def test_load_enables_cpu_offload_on_cuda(
+    def test_load_enables_group_offload_on_cuda(
         self, mock_zimage_pipeline, mock_img2img_pipeline, mock_inpaint_pipeline
     ):
-        """Load enables CPU offload on CUDA by default."""
+        """Load enables group offload on CUDA by default."""
         mock_pipe = MagicMock()
         mock_pipe.components = make_zimage_components()
         mock_zimage_pipeline.from_pretrained.return_value = mock_pipe
@@ -102,7 +102,7 @@ class TestZImagePipelineWrapperLoad:
             pipeline = ZImagePipelineWrapper()
             pipeline.load({})
 
-        mock_pipe.enable_model_cpu_offload.assert_called_once()
+        mock_pipe.enable_group_offload.assert_called_once()
         mock_img2img_pipeline.assert_called_once_with(**mock_pipe.components)
         mock_inpaint_pipeline.assert_called_once_with(**mock_pipe.components)
 
@@ -120,6 +120,7 @@ class TestZImagePipelineWrapperLoad:
         pipeline = ZImagePipelineWrapper()
         pipeline.load({"cpu_offload": False})
 
+        mock_pipe.enable_group_offload.assert_not_called()
         mock_pipe.enable_model_cpu_offload.assert_not_called()
         mock_img2img_pipeline.assert_called_once_with(**mock_pipe.components)
         mock_inpaint_pipeline.assert_called_once_with(**mock_pipe.components)


### PR DESCRIPTION
Default CUDA pipelines to Diffusers group offload while keeping model and sequential fallback modes for low-memory compatibility.

Fixes: #94