### PR TITLE
feat: add flux2 klein pipeline

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -26,6 +26,15 @@ group_offload_type = "leaf_level"
 steps = 28
 guidance_scale = 4.0
 
+[models.flux2-klein]
+type = "flux2-klein"
+repo = "black-forest-labs/FLUX.2-klein-9B"
+cpu_offload = true
+offload_type = "group"
+group_offload_type = "leaf_level"
+steps = 4
+guidance_scale = 1.0  # Distilled Klein model-card default; base variants use 4.0/50 steps
+
 [models.qwen-image]
 type = "qwen"
 repo = "Qwen/Qwen-Image"

--- a/src/oneiro/pipelines/__init__.py
+++ b/src/oneiro/pipelines/__init__.py
@@ -17,6 +17,7 @@ from oneiro.pipelines.civitai_checkpoint import (
 )
 from oneiro.pipelines.flux1 import Flux1PipelineWrapper
 from oneiro.pipelines.flux2 import Flux2PipelineWrapper
+from oneiro.pipelines.flux2_klein import Flux2KleinPipelineWrapper
 from oneiro.pipelines.lora import (
     LoraConfig,
     LoraIncompatibleError,
@@ -39,6 +40,7 @@ __all__ = [
     "PipelineManager",
     "Flux1PipelineWrapper",
     "Flux2PipelineWrapper",
+    "Flux2KleinPipelineWrapper",
     "QwenPipelineWrapper",
     "ZImagePipelineWrapper",
     "CivitaiCheckpointPipeline",
@@ -64,6 +66,7 @@ class PipelineManager:
         "zimage": ZImagePipelineWrapper,
         "flux1": Flux1PipelineWrapper,
         "flux2": Flux2PipelineWrapper,
+        "flux2-klein": Flux2KleinPipelineWrapper,
         "qwen": QwenPipelineWrapper,
         "civitai": CivitaiCheckpointPipeline,
     }

--- a/src/oneiro/pipelines/civitai_checkpoint.py
+++ b/src/oneiro/pipelines/civitai_checkpoint.py
@@ -1373,6 +1373,24 @@ class CivitaiCheckpointPipeline(LoraLoaderMixin, EmbeddingLoaderMixin, BasePipel
 
             return gen_kwargs
 
+        if self._pipeline_config.pipeline_class == "Flux2KleinPipeline":
+            gen_kwargs = {
+                "prompt": prompt,
+                "num_inference_steps": steps,
+                "guidance_scale": guidance_scale,
+                "generator": generator,
+            }
+
+            if init_image:
+                print(f"CivitAI FLUX.2 Klein img2img: '{prompt[:50]}...'")
+                gen_kwargs["image"] = init_image
+            else:
+                print(f"CivitAI FLUX.2 Klein generating: '{prompt[:50]}...'")
+                gen_kwargs["height"] = height
+                gen_kwargs["width"] = width
+
+            return gen_kwargs
+
         gen_kwargs: dict[str, Any] = {
             "num_inference_steps": steps,
             "guidance_scale": guidance_scale,

--- a/src/oneiro/pipelines/flux2_klein.py
+++ b/src/oneiro/pipelines/flux2_klein.py
@@ -1,0 +1,120 @@
+"""FLUX.2 Klein pipeline wrapper with CPU offloading, LoRA, and embedding support."""
+
+from typing import Any
+
+import torch
+from PIL import Image
+
+from oneiro.device import DevicePolicy
+from oneiro.pipelines.base import BasePipeline, GenerationResult
+from oneiro.pipelines.embedding import EmbeddingLoaderMixin, parse_embeddings_from_config
+from oneiro.pipelines.lora import LoraLoaderMixin, parse_loras_from_model_config
+
+
+class Flux2KleinPipelineWrapper(LoraLoaderMixin, EmbeddingLoaderMixin, BasePipeline):
+    """Wrapper for lightweight FLUX.2 Klein models."""
+
+    def __init__(self) -> None:
+        super().__init__()
+
+    def load(self, model_config: dict[str, Any], full_config: dict[str, Any] | None = None) -> None:
+        """Load FLUX.2 Klein from a hosted Diffusers repository."""
+        from diffusers import Flux2KleinPipeline
+
+        repo = model_config.get("repo", "black-forest-labs/FLUX.2-klein-9B")
+        cpu_offload = model_config.get("cpu_offload", True)
+        offload_type = model_config.get("offload_type", "group")
+        group_offload_type = model_config.get("group_offload_type", "leaf_level")
+        group_offload_use_stream = model_config.get("group_offload_use_stream", True)
+        group_offload_num_blocks_per_group = model_config.get("group_offload_num_blocks_per_group")
+        cpu_utilization = model_config.get("cpu_utilization", 0.75)
+
+        print(f"Loading FLUX.2 Klein from {repo}")
+
+        self._configure_cpu_threads(cpu_utilization)
+
+        self.policy = DevicePolicy.auto_detect(
+            cpu_offload=cpu_offload,
+            offload_type=offload_type,
+            group_offload_type=group_offload_type,
+            group_offload_use_stream=group_offload_use_stream,
+            group_offload_num_blocks_per_group=group_offload_num_blocks_per_group,
+        )
+
+        self.pipe = Flux2KleinPipeline.from_pretrained(
+            repo,
+            torch_dtype=self.policy.dtype,
+        )
+
+        loras = parse_loras_from_model_config(model_config)
+        if loras:
+            print(f"  Loading {len(loras)} LoRA(s)...")
+            self.load_loras_sync(loras)
+            self.set_static_loras(loras)
+
+        if full_config:
+            embeddings = parse_embeddings_from_config(full_config, model_config)
+            if embeddings:
+                print(f"  Loading {len(embeddings)} embedding(s)...")
+                self.load_embeddings_sync(embeddings)
+
+        self.policy.apply_to_pipeline(self.pipe)
+
+        print(f"FLUX.2 Klein loaded from {repo}")
+
+    def generate(
+        self,
+        prompt: str,
+        negative_prompt: str | None = None,
+        width: int = 1024,
+        height: int = 1024,
+        seed: int = -1,
+        steps: int = 4,
+        guidance_scale: float = 1.0,
+        **kwargs: Any,
+    ) -> GenerationResult:
+        """Generate image with current FLUX.2 Klein distilled model-card defaults."""
+        return super().generate(
+            prompt=prompt,
+            negative_prompt=negative_prompt,
+            width=width,
+            height=height,
+            seed=seed,
+            steps=steps,
+            guidance_scale=guidance_scale,
+            **kwargs,
+        )
+
+    def build_generation_kwargs(
+        self,
+        prompt: str,
+        negative_prompt: str | None,
+        width: int,
+        height: int,
+        steps: int,
+        guidance_scale: float,
+        generator: torch.Generator,
+        init_image: Image.Image | None,
+        strength: float,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        """Build FLUX.2 Klein generation kwargs."""
+        gen_kwargs: dict[str, Any] = {
+            "prompt": prompt,
+            "height": height,
+            "width": width,
+            "num_inference_steps": steps,
+            "guidance_scale": guidance_scale,
+            "generator": generator,
+        }
+        if init_image is not None:
+            print(f"FLUX.2 Klein img2img: '{prompt[:50]}...'")
+            gen_kwargs["image"] = init_image
+        else:
+            print(f"FLUX.2 Klein generating: '{prompt[:50]}...'")
+        return gen_kwargs
+
+    def post_generate(self, **kwargs: Any) -> None:
+        """Reset LoRA state after generation to prevent state leakage."""
+        super().post_generate(**kwargs)
+        self.restore_static_loras()

--- a/src/oneiro/pipelines/lora.py
+++ b/src/oneiro/pipelines/lora.py
@@ -456,10 +456,11 @@ def parse_loras_from_config(
 
 
 # Pipeline type to Civitai base model mapping
-# FLUX.1 and FLUX.2 are NOT LoRA-compatible due to different transformer architectures
+# FLUX.1, FLUX.2, and FLUX.2 Klein use distinct transformer families.
 PIPELINE_BASE_MODEL_MAP: dict[str, list[str]] = {
     "flux1": ["Flux.1 D", "Flux.1 S", "Flux.1", "Flux.1 Dev", "Flux.1 Schnell"],
     "flux2": ["Flux.2"],
+    "flux2-klein": ["Flux.2 Klein", "FLUX.2-klein"],
     "zimage": ["ZImageTurbo", "ZImageBase", "Z-Image"],
     "qwen": ["Qwen", "Qwen-Image"],
     "sdxl": ["SDXL 1.0", "SDXL Turbo", "SDXL Lightning", "Pony", "Illustrious"],
@@ -487,8 +488,13 @@ def is_resource_compatible(pipeline_type: str, civitai_base_model: str | None) -
         # Unknown pipeline type, assume compatible
         return True
 
-    # Check if any compatible base model matches (case-insensitive substring)
     civitai_lower = civitai_base_model.lower()
+    if pipeline_type == "flux2":
+        return "flux.2" in civitai_lower and "klein" not in civitai_lower
+    if pipeline_type == "flux2-klein":
+        return ("flux.2" in civitai_lower or "flux2" in civitai_lower) and "klein" in civitai_lower
+
+    # Check if any compatible base model matches (case-insensitive substring)
     for base in compatible_bases:
         if base.lower() in civitai_lower or civitai_lower in base.lower():
             return True

--- a/tests/test_civitai_checkpoint.py
+++ b/tests/test_civitai_checkpoint.py
@@ -1521,6 +1521,40 @@ class TestCivitaiCheckpointPipelineGenerate:
         assert "width" not in call_kwargs
         assert "height" not in call_kwargs
 
+    def test_generate_flux2_klein_img2img_omits_strength(self):
+        """Flux2 Klein accepts image input but not img2img strength."""
+        pipeline = CivitaiCheckpointPipeline()
+        pipeline._pipeline_config = PipelineConfig(
+            pipeline_class="Flux2KleinPipeline",
+            supports_negative_prompt=False,
+            default_steps=4,
+            default_guidance_scale=1.0,
+        )
+
+        mock_pipe = MagicMock()
+        mock_image = MagicMock()
+        mock_image.width = 1024
+        mock_image.height = 1024
+        mock_pipe.return_value.images = [mock_image]
+        pipeline.pipe = mock_pipe
+
+        mock_init_image = MagicMock()
+        with (
+            patch.object(DevicePolicy, "clear_cache"),
+            patch.object(pipeline, "_load_init_image", return_value=mock_init_image),
+        ):
+            pipeline.generate("test prompt", init_image=b"dummy", strength=0.5)
+
+        call_kwargs = mock_pipe.call_args.kwargs
+        assert call_kwargs["prompt"] == "test prompt"
+        assert call_kwargs["image"] == mock_init_image
+        assert call_kwargs["num_inference_steps"] == 4
+        assert call_kwargs["guidance_scale"] == 1.0
+        assert "strength" not in call_kwargs
+        assert "negative_prompt" not in call_kwargs
+        assert "width" not in call_kwargs
+        assert "height" not in call_kwargs
+
     def test_generate_with_scheduler_override(self):
         pipeline = CivitaiCheckpointPipeline()
         pipeline._pipeline_config = PipelineConfig(

--- a/tests/test_embedding.py
+++ b/tests/test_embedding.py
@@ -351,6 +351,10 @@ class TestIsEmbeddingCompatible:
     def test_flux2_compatible(self):
         """Flux.2 embeddings compatible with flux2 pipeline."""
         assert is_resource_compatible("flux2", "Flux.2")
+        assert is_resource_compatible("flux2-klein", "Flux.2 Klein 9B")
+        assert is_resource_compatible("flux2-klein", "FLUX.2-klein-4B")
+        assert not is_resource_compatible("flux2", "Flux.2 Klein 9B")
+        assert not is_resource_compatible("flux2-klein", "Flux.2")
 
     def test_flux1_flux2_incompatible(self):
         """Flux.1 and Flux.2 embeddings are NOT cross-compatible."""
@@ -406,7 +410,7 @@ class TestPipelineBaseModelMap:
 
     def test_all_pipeline_types_have_mappings(self):
         """All common pipeline types have base model mappings."""
-        expected_types = ["flux2", "zimage", "qwen", "sdxl", "sd15"]
+        expected_types = ["flux2", "flux2-klein", "zimage", "qwen", "sdxl", "sd15"]
         for pipeline_type in expected_types:
             assert pipeline_type in PIPELINE_BASE_MODEL_MAP
             assert len(PIPELINE_BASE_MODEL_MAP[pipeline_type]) > 0

--- a/tests/test_lora.py
+++ b/tests/test_lora.py
@@ -582,7 +582,11 @@ class TestIsLoraCompatible:
         assert is_resource_compatible("flux1", "Flux.1 Schnell")
         assert is_resource_compatible("flux1", "Flux.1 D")
         assert is_resource_compatible("flux2", "Flux.2")
+        assert is_resource_compatible("flux2-klein", "Flux.2 Klein 9B")
+        assert is_resource_compatible("flux2-klein", "FLUX.2-klein-4B")
         assert not is_resource_compatible("flux2", "Flux.1 Dev")
+        assert not is_resource_compatible("flux2", "Flux.2 Klein 9B")
+        assert not is_resource_compatible("flux2-klein", "Flux.2")
 
     def test_sdxl_compatible(self):
         """SDXL LoRAs compatible with sdxl pipeline."""
@@ -633,7 +637,7 @@ class TestPipelineBaseModelMap:
 
     def test_all_pipeline_types_have_mappings(self):
         """All common pipeline types have base model mappings."""
-        expected_types = ["flux2", "zimage", "qwen", "sdxl", "sd15"]
+        expected_types = ["flux2", "flux2-klein", "zimage", "qwen", "sdxl", "sd15"]
         for pipeline_type in expected_types:
             assert pipeline_type in PIPELINE_BASE_MODEL_MAP
             assert len(PIPELINE_BASE_MODEL_MAP[pipeline_type]) > 0

--- a/tests/test_pipelines_base.py
+++ b/tests/test_pipelines_base.py
@@ -11,6 +11,7 @@ from PIL import Image
 from oneiro.device import DevicePolicy, OffloadMode, OffloadType
 from oneiro.pipelines import PipelineManager
 from oneiro.pipelines.base import BasePipeline, GenerationResult
+from oneiro.pipelines.flux2_klein import Flux2KleinPipelineWrapper
 from oneiro.pipelines.lora import LoraConfig, LoraSource
 
 
@@ -112,6 +113,14 @@ class TestBasePipelineInit:
         with patch.object(DevicePolicy, "auto_detect", return_value=mock_policy):
             pipeline = ConcretePipeline()
         assert pipeline.policy.device == "cpu"
+
+
+class TestPipelineManagerRegistry:
+    """Tests for pipeline manager registration."""
+
+    def test_registers_flux2_klein_pipeline_type(self):
+        """PipelineManager exposes the dedicated FLUX.2 Klein wrapper."""
+        assert PipelineManager.PIPELINE_TYPES["flux2-klein"] is Flux2KleinPipelineWrapper
 
 
 class TestBasePipelineUnload:

--- a/tests/test_pipelines_flux2_klein.py
+++ b/tests/test_pipelines_flux2_klein.py
@@ -1,0 +1,196 @@
+"""Tests for pipelines.flux2_klein module."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+from PIL import Image
+
+from oneiro.device import DevicePolicy, OffloadMode
+from oneiro.pipelines.flux2_klein import Flux2KleinPipelineWrapper
+
+
+class TestFlux2KleinPipelineWrapperInit:
+    """Tests for Flux2KleinPipelineWrapper initialization."""
+
+    def test_init_creates_instance(self):
+        """Flux2KleinPipelineWrapper can be instantiated."""
+        mock_policy = DevicePolicy(device="cpu", dtype=torch.float32, offload=OffloadMode.NEVER)
+        with patch.object(DevicePolicy, "auto_detect", return_value=mock_policy):
+            pipeline = Flux2KleinPipelineWrapper()
+        assert pipeline.pipe is None
+        assert pipeline.policy.device == "cpu"
+
+
+class TestFlux2KleinPipelineWrapperLoad:
+    """Tests for Flux2KleinPipelineWrapper.load()."""
+
+    @patch("oneiro.pipelines.base.torch.set_num_interop_threads")
+    @patch("oneiro.pipelines.base.torch.set_num_threads")
+    @patch("diffusers.Flux2KleinPipeline")
+    def test_load_with_default_repo(self, mock_flux2_klein_pipeline, mock_threads, mock_interop):
+        """Load uses the 9B distilled Klein repo when not specified."""
+        mock_pipe = MagicMock()
+        mock_flux2_klein_pipeline.from_pretrained.return_value = mock_pipe
+
+        pipeline = Flux2KleinPipelineWrapper()
+        pipeline.load({})
+
+        mock_flux2_klein_pipeline.from_pretrained.assert_called_once_with(
+            "black-forest-labs/FLUX.2-klein-9B",
+            torch_dtype=pipeline.policy.dtype,
+        )
+
+    @patch("oneiro.pipelines.base.torch.set_num_interop_threads")
+    @patch("oneiro.pipelines.base.torch.set_num_threads")
+    @patch("diffusers.Flux2KleinPipeline")
+    def test_load_with_custom_repo(self, mock_flux2_klein_pipeline, mock_threads, mock_interop):
+        """Load uses custom repo from config."""
+        mock_pipe = MagicMock()
+        mock_flux2_klein_pipeline.from_pretrained.return_value = mock_pipe
+
+        pipeline = Flux2KleinPipelineWrapper()
+        pipeline.load({"repo": "black-forest-labs/FLUX.2-klein-4B"})
+
+        call_args = mock_flux2_klein_pipeline.from_pretrained.call_args
+        assert call_args.args[0] == "black-forest-labs/FLUX.2-klein-4B"
+
+    @patch("oneiro.pipelines.base.torch.set_num_interop_threads")
+    @patch("oneiro.pipelines.base.torch.set_num_threads")
+    @patch("diffusers.Flux2KleinPipeline")
+    def test_load_enables_group_offload_on_cuda(
+        self, mock_flux2_klein_pipeline, mock_threads, mock_interop
+    ):
+        """Load enables group offload on CUDA by default."""
+        mock_pipe = MagicMock()
+        mock_flux2_klein_pipeline.from_pretrained.return_value = mock_pipe
+
+        mock_policy = DevicePolicy(device="cuda", dtype=torch.float16, offload=OffloadMode.AUTO)
+        with patch.object(DevicePolicy, "auto_detect", return_value=mock_policy):
+            pipeline = Flux2KleinPipelineWrapper()
+            pipeline.load({})
+
+        mock_pipe.enable_group_offload.assert_called_once()
+
+    @patch("oneiro.pipelines.base.torch.set_num_interop_threads")
+    @patch("oneiro.pipelines.base.torch.set_num_threads")
+    @patch("diffusers.Flux2KleinPipeline")
+    def test_load_disables_cpu_offload_when_configured(
+        self, mock_flux2_klein_pipeline, mock_threads, mock_interop
+    ):
+        """Load respects cpu_offload=False config."""
+        mock_pipe = MagicMock()
+        mock_flux2_klein_pipeline.from_pretrained.return_value = mock_pipe
+
+        pipeline = Flux2KleinPipelineWrapper()
+        pipeline.load({"cpu_offload": False})
+
+        mock_pipe.enable_group_offload.assert_not_called()
+        mock_pipe.enable_model_cpu_offload.assert_not_called()
+
+
+class TestFlux2KleinPipelineWrapperGenerate:
+    """Tests for Flux2KleinPipelineWrapper.generate()."""
+
+    def test_generate_raises_when_not_loaded(self):
+        """Generate raises RuntimeError when pipeline not loaded."""
+        mock_policy = DevicePolicy(device="cpu", dtype=torch.float32, offload=OffloadMode.NEVER)
+        with patch.object(DevicePolicy, "auto_detect", return_value=mock_policy):
+            pipeline = Flux2KleinPipelineWrapper()
+            with pytest.raises(RuntimeError, match="Pipeline not loaded"):
+                pipeline.generate("test prompt")
+
+    def test_generate_returns_result(self):
+        """Generate returns GenerationResult with correct fields."""
+        mock_policy = DevicePolicy(device="cpu", dtype=torch.float32, offload=OffloadMode.NEVER)
+        with patch.object(DevicePolicy, "auto_detect", return_value=mock_policy):
+            pipeline = Flux2KleinPipelineWrapper()
+            mock_pipe = MagicMock()
+            mock_image = Image.new("RGB", (1024, 1024), color="blue")
+            mock_pipe.return_value.images = [mock_image]
+            pipeline.pipe = mock_pipe
+
+            result = pipeline.generate("a fast preview", seed=42)
+
+            assert result.image is mock_image
+            assert result.seed == 42
+            assert result.prompt == "a fast preview"
+            assert result.width == 1024
+            assert result.height == 1024
+
+    def test_generate_uses_distilled_defaults(self):
+        """Generate uses distilled FLUX.2 Klein defaults."""
+        mock_policy = DevicePolicy(device="cpu", dtype=torch.float32, offload=OffloadMode.NEVER)
+        with patch.object(DevicePolicy, "auto_detect", return_value=mock_policy):
+            pipeline = Flux2KleinPipelineWrapper()
+            mock_pipe = MagicMock()
+            mock_pipe.return_value.images = [Image.new("RGB", (1024, 1024))]
+            pipeline.pipe = mock_pipe
+
+            pipeline.generate("test prompt", seed=42)
+
+            call_kwargs = mock_pipe.call_args.kwargs
+            assert call_kwargs["num_inference_steps"] == 4
+            assert call_kwargs["guidance_scale"] == 1.0
+
+    def test_generate_with_custom_parameters(self):
+        """Generate respects custom parameters."""
+        mock_policy = DevicePolicy(device="cpu", dtype=torch.float32, offload=OffloadMode.NEVER)
+        with patch.object(DevicePolicy, "auto_detect", return_value=mock_policy):
+            pipeline = Flux2KleinPipelineWrapper()
+            mock_pipe = MagicMock()
+            mock_pipe.return_value.images = [Image.new("RGB", (512, 512))]
+            pipeline.pipe = mock_pipe
+
+            result = pipeline.generate(
+                "test prompt",
+                width=512,
+                height=512,
+                seed=123,
+                steps=20,
+                guidance_scale=5.0,
+            )
+
+            call_kwargs = mock_pipe.call_args.kwargs
+            assert call_kwargs["width"] == 512
+            assert call_kwargs["height"] == 512
+            assert call_kwargs["num_inference_steps"] == 20
+            assert call_kwargs["guidance_scale"] == 5.0
+            assert result.steps == 20
+            assert result.guidance_scale == 5.0
+
+    def test_generate_stores_negative_prompt_in_result(self):
+        """Generate stores negative_prompt in result but does not pass it to pipeline."""
+        mock_policy = DevicePolicy(device="cpu", dtype=torch.float32, offload=OffloadMode.NEVER)
+        with patch.object(DevicePolicy, "auto_detect", return_value=mock_policy):
+            pipeline = Flux2KleinPipelineWrapper()
+            mock_pipe = MagicMock()
+            mock_pipe.return_value.images = [Image.new("RGB", (1024, 1024))]
+            pipeline.pipe = mock_pipe
+
+            result = pipeline.generate("test prompt", negative_prompt="blurry", seed=42)
+
+            assert result.negative_prompt == "blurry"
+            call_kwargs = mock_pipe.call_args.kwargs
+            assert "negative_prompt" not in call_kwargs
+
+    def test_generate_with_init_image(self):
+        """Generate passes init image to FLUX.2 Klein without unsupported strength."""
+        import io
+
+        mock_policy = DevicePolicy(device="cpu", dtype=torch.float32, offload=OffloadMode.NEVER)
+        with patch.object(DevicePolicy, "auto_detect", return_value=mock_policy):
+            pipeline = Flux2KleinPipelineWrapper()
+            mock_pipe = MagicMock()
+            mock_pipe.return_value.images = [Image.new("RGB", (1024, 1024))]
+            pipeline.pipe = mock_pipe
+
+            init_img = Image.new("RGB", (512, 512), color="red")
+            buffer = io.BytesIO()
+            init_img.save(buffer, format="PNG")
+
+            pipeline.generate("test prompt", seed=42, init_image=buffer.getvalue(), strength=0.5)
+
+            call_kwargs = mock_pipe.call_args.kwargs
+            assert "image" in call_kwargs
+            assert "strength" not in call_kwargs


### PR DESCRIPTION
Add a dedicated FLUX.2 Klein wrapper and registration so lightweight hosted Klein models can use the shared offload, LoRA, and embedding paths.

Fixes: #96