### PR TITLE
fix(krea2): load CivitAI checkpoints

### DIFF
--- a/src/oneiro/civitai.py
+++ b/src/oneiro/civitai.py
@@ -165,6 +165,34 @@ class ModelVersion:
                 return f
         return self.files[0] if self.files else None
 
+    def select_checkpoint_file(
+        self,
+        precision: str = "auto",
+        preferred_precision: str = "bf16",
+    ) -> ModelFile:
+        """Select the best floating-point SafeTensor checkpoint for Diffusers."""
+        supported_precisions = ("bf16", "fp16", "fp32")
+        weight_file_types = {"model", "unet", "diffusion model"}
+        candidates = [
+            file
+            for file in self.files
+            if file.type.lower() in weight_file_types
+            and (file.format or "").lower() == "safetensor"
+            and (file.fp or "").lower() in supported_precisions
+        ]
+        if not candidates:
+            raise CivitaiError("No Diffusers-compatible floating-point SafeTensor checkpoint found")
+
+        if precision != "auto":
+            candidates = [file for file in candidates if (file.fp or "").lower() == precision]
+            if not candidates:
+                raise CivitaiError(f"No {precision} SafeTensor checkpoint found")
+
+        precision_order = (preferred_precision,) + tuple(
+            item for item in supported_precisions if item != preferred_precision
+        )
+        return min(candidates, key=lambda file: precision_order.index((file.fp or "").lower()))
+
 
 @dataclass
 class Model:
@@ -336,6 +364,7 @@ class CivitaiClient:
 
     BASE_URL = "https://civitai.com/api/v1"
     DEFAULT_CACHE_DIR = Path.home() / ".cache" / "civitai"
+    MAX_SAFETENSOR_HEADER_BYTES = 1_000_000
 
     def __init__(
         self,
@@ -618,10 +647,7 @@ class CivitaiClient:
         client = await self._ensure_client()
 
         # Add API key as query param for download URLs if authenticated
-        download_url = url
-        if self.api_key and "civitai.com" in url:
-            separator = "&" if "?" in url else "?"
-            download_url = f"{url}{separator}token={self.api_key}"
+        download_url = self._authenticated_download_url(url)
 
         try:
             async with client.stream(
@@ -680,53 +706,137 @@ class CivitaiClient:
 
         return dest
 
+    def _authenticated_download_url(self, url: str) -> str:
+        """Add the CivitAI download token when configured."""
+        if self.api_key and "civitai.com" in url:
+            separator = "&" if "?" in url else "?"
+            return f"{url}{separator}token={self.api_key}"
+        return url
+
+    async def _read_download_prefix(self, url: str, length: int) -> bytes:
+        """Read only the requested prefix of a remote download."""
+        client = await self._ensure_client()
+        try:
+            async with client.stream(
+                "GET",
+                self._authenticated_download_url(url),
+                headers={
+                    "Range": f"bytes=0-{length - 1}",
+                    "Accept-Encoding": "identity",
+                },
+                timeout=httpx.Timeout(self.download_timeout),
+            ) as response:
+                response.raise_for_status()
+                if response.status_code == 206 and not response.headers.get(
+                    "Content-Range", ""
+                ).startswith("bytes 0-"):
+                    raise CivitaiError("SafeTensor server returned an invalid byte range")
+                data = bytearray()
+                async for chunk in response.aiter_raw():
+                    data.extend(chunk[: length - len(data)])
+                    if len(data) == length:
+                        break
+        except httpx.HTTPStatusError as error:
+            raise CivitaiError(
+                f"SafeTensor header request failed: HTTP {error.response.status_code}"
+            ) from error
+        except httpx.RequestError as error:
+            raise CivitaiError(f"SafeTensor header request failed: {error}") from error
+
+        if len(data) != length:
+            raise CivitaiError("SafeTensor file ended before its header was complete")
+        return bytes(data)
+
+    async def get_safetensor_header(self, url: str) -> dict[str, Any]:
+        """Read a SafeTensor JSON header using two bounded range requests."""
+        prefix = await self._read_download_prefix(url, 8)
+        header_size = int.from_bytes(prefix, "little")
+        if not 0 < header_size <= self.MAX_SAFETENSOR_HEADER_BYTES:
+            raise CivitaiError("Invalid SafeTensor header size")
+
+        payload = await self._read_download_prefix(url, 8 + header_size)
+        try:
+            header = json.loads(payload[8:].decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as error:
+            raise CivitaiError("Invalid SafeTensor header") from error
+        if not isinstance(header, dict):
+            raise CivitaiError("Invalid SafeTensor header")
+        metadata = header.get("__metadata__", {})
+        if not isinstance(metadata, dict):
+            raise CivitaiError("Invalid SafeTensor metadata")
+        for key, descriptor in header.items():
+            if key == "__metadata__":
+                continue
+            if not isinstance(descriptor, dict):
+                raise CivitaiError("Invalid SafeTensor tensor descriptor")
+            shape = descriptor.get("shape")
+            offsets = descriptor.get("data_offsets")
+            if (
+                not isinstance(descriptor.get("dtype"), str)
+                or not isinstance(shape, list)
+                or any(not isinstance(size, int) or size < 0 for size in shape)
+                or not isinstance(offsets, list)
+                or len(offsets) != 2
+                or any(not isinstance(offset, int) or offset < 0 for offset in offsets)
+                or offsets[0] > offsets[1]
+            ):
+                raise CivitaiError("Invalid SafeTensor tensor descriptor")
+        return header
+
     async def download_model_version(
         self,
         version: ModelVersion,
         dest_dir: Path | str | None = None,
         progress_callback: Callable[[int, int], Awaitable[None]] | None = None,
+        model_file: ModelFile | None = None,
     ) -> Path:
-        """Download the primary file for a model version.
+        """Download a selected or primary file for a model version.
 
         Args:
             version: ModelVersion to download
             dest_dir: Destination directory (default: cache_dir/models)
             progress_callback: Progress callback
+            model_file: Specific file to download (default: primary file)
 
         Returns:
             Path to downloaded file
         """
-        primary = version.primary_file
-        if not primary:
+        selected = model_file or version.primary_file
+        if not selected:
             raise CivitaiError(f"No files available for version {version.id}")
 
         # Check cache first
-        if primary.sha256:
-            cached = self._cache.get(primary.sha256)
+        if selected.sha256:
+            cached = self._cache.get(selected.sha256)
             if cached:
                 print(f"Model found in cache: {cached}")
                 return cached
 
         dest_dir = Path(dest_dir) if dest_dir else self.cache_dir / "models"
         dest_dir.mkdir(parents=True, exist_ok=True)
-        dest = dest_dir / primary.name
+        filename = selected.name
+        if model_file is not None:
+            path = Path(filename)
+            variant = f"{selected.fp}-{selected.id}" if selected.fp else str(selected.id)
+            filename = f"{path.stem}-{variant}{path.suffix}"
+        dest = dest_dir / filename
 
         downloaded = await self.download_file(
-            url=primary.download_url,
+            url=selected.download_url,
             dest=dest,
-            expected_hash=primary.sha256,
+            expected_hash=selected.sha256,
             progress_callback=progress_callback,
         )
 
         # Add to cache if we have a hash
-        if primary.sha256:
+        if selected.sha256:
             self._cache.add(
                 file_path=downloaded,
-                sha256=primary.sha256,
+                sha256=selected.sha256,
                 model_id=version.model_id,
                 version_id=version.id,
-                filename=primary.name,
-                size_kb=primary.size_kb,
+                filename=filename,
+                size_kb=selected.size_kb,
             )
 
         return downloaded

--- a/src/oneiro/discord/commands.py
+++ b/src/oneiro/discord/commands.py
@@ -1,15 +1,26 @@
 """Slash command definitions for Oneiro Discord bot."""
 
 import re
+from contextlib import suppress
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import discord
 from discord import option
 
-from oneiro.civitai import CivitaiError, parse_civitai_url
+from oneiro.civitai import CivitaiClient, CivitaiError, ModelFile, parse_civitai_url
+from oneiro.device import DevicePolicy
 from oneiro.discord.handlers import DreamContext, create_dream_callbacks
 from oneiro.pipelines import SCHEDULER_CHOICES
-from oneiro.pipelines.civitai_checkpoint import CivitaiCheckpointPipeline
+from oneiro.pipelines.civitai_checkpoint import (
+    DEFAULT_KREA2_COMPONENT_REPO,
+    DEFAULT_KREA2_RAW_COMPONENT_REPO,
+    CivitaiCheckpointPipeline,
+    get_krea2_checkpoint_precision,
+    get_krea2_checkpoint_precision_from_header,
+    get_krea2_generation_defaults,
+    get_pipeline_config_for_base_model,
+)
 from oneiro.pipelines.lora import is_resource_compatible
 from oneiro.queue import QueueStatus
 from oneiro.services.generation import (
@@ -49,6 +60,48 @@ def slugify(text: str) -> str:
     # Remove leading/trailing hyphens
     slug = slug.strip("-")
     return slug or "unnamed"
+
+
+def is_krea2_base_model(base_model: str | None) -> bool:
+    """Return whether CivitAI metadata resolves to the Krea 2 pipeline."""
+    if base_model is None:
+        return False
+    try:
+        return get_pipeline_config_for_base_model(base_model).pipeline_class == "Krea2Pipeline"
+    except ValueError:
+        return False
+
+
+def krea2_component_repo(
+    model_name: str,
+    version_name: str,
+    variant: str = "auto",
+) -> str:
+    """Choose hosted Krea components from CivitAI model and version names."""
+    if variant == "raw":
+        return DEFAULT_KREA2_RAW_COMPONENT_REPO
+    if variant == "turbo":
+        return DEFAULT_KREA2_COMPONENT_REPO
+    for name in (version_name, model_name):
+        normalized = name.lower()
+        if re.search(r"(?<![a-z])turbo(?![a-z])", normalized):
+            return DEFAULT_KREA2_COMPONENT_REPO
+        if re.search(r"(?<![a-z])raw(?![a-z])", normalized):
+            return DEFAULT_KREA2_RAW_COMPONENT_REPO
+    return DEFAULT_KREA2_COMPONENT_REPO
+
+
+def _discard_invalid_civitai_download(
+    client: CivitaiClient,
+    model_file: ModelFile,
+    path: Path,
+) -> None:
+    """Best-effort removal of a rejected download and its cache entry."""
+    if model_file.sha256:
+        with suppress(Exception):
+            client.cache.remove(model_file.sha256)
+    with suppress(OSError):
+        path.unlink(missing_ok=True)
 
 
 def validate_image_attachment(attachment: discord.Attachment, label: str) -> str | None:
@@ -609,10 +662,26 @@ def register_commands(bot: "OneiroBot") -> None:
         description="Custom name for the resource (default: slugified model name)",
         required=False,
     )
+    @option(
+        "precision",
+        str,
+        description="Checkpoint precision (Krea 2 only)",
+        required=False,
+        choices=["auto", "bf16", "fp16", "fp32"],
+    )
+    @option(
+        "krea2_variant",
+        str,
+        description="Krea 2 component recipe override",
+        required=False,
+        choices=["auto", "turbo", "raw"],
+    )
     async def fetch_command(
         ctx: discord.ApplicationContext,
         url: str,
         name: str | None = None,
+        precision: str = "auto",
+        krea2_variant: str = "auto",
     ) -> None:
         """Fetch a model from Civitai and auto-configure it."""
         if ctx.bot.config is None or ctx.bot.civitai_client is None:
@@ -687,7 +756,57 @@ def register_commands(bot: "OneiroBot") -> None:
             )
 
             # Download the model
-            downloaded_path = await ctx.bot.civitai_client.download_model_version(version)
+            selected_file = None
+            selected_precision = None
+            component_repo = None
+            cached_checkpoint = None
+            if model_type == "CHECKPOINT" and is_krea2_base_model(version.base_model):
+                policy_precision = {
+                    "bfloat16": "bf16",
+                    "float16": "fp16",
+                    "float32": "fp32",
+                }[str(DevicePolicy.auto_detect().dtype).removeprefix("torch.")]
+                selected_file = version.select_checkpoint_file(
+                    precision,
+                    preferred_precision=policy_precision,
+                )
+                component_repo = krea2_component_repo(
+                    model.name,
+                    version.name,
+                    krea2_variant,
+                )
+                if selected_file.sha256:
+                    cached_checkpoint = ctx.bot.civitai_client.cache.get(selected_file.sha256)
+                try:
+                    if cached_checkpoint:
+                        selected_precision = get_krea2_checkpoint_precision(cached_checkpoint)
+                    else:
+                        header = await ctx.bot.civitai_client.get_safetensor_header(
+                            selected_file.download_url
+                        )
+                        selected_precision = get_krea2_checkpoint_precision_from_header(header)
+                except Exception as error:
+                    if cached_checkpoint:
+                        _discard_invalid_civitai_download(
+                            ctx.bot.civitai_client,
+                            selected_file,
+                            cached_checkpoint,
+                        )
+                    raise CivitaiError(str(error)) from error
+            downloaded_path = await ctx.bot.civitai_client.download_model_version(
+                version,
+                model_file=selected_file,
+            )
+            if selected_file:
+                try:
+                    selected_precision = get_krea2_checkpoint_precision(downloaded_path)
+                except Exception as error:
+                    _discard_invalid_civitai_download(
+                        ctx.bot.civitai_client,
+                        selected_file,
+                        downloaded_path,
+                    )
+                    raise CivitaiError(str(error)) from error
 
             # Get current pipeline type for compatibility info
             pipeline_type = None
@@ -746,17 +865,27 @@ def register_commands(bot: "OneiroBot") -> None:
 
             elif model_type == "CHECKPOINT":
                 # For checkpoints, we need to add to models section
+                checkpoint_config = {
+                    "type": "civitai",
+                    "civitai_id": model_id,
+                    "civitai_version": version.id,
+                    "name": model.name,
+                    "base_model": version.base_model,
+                    "checkpoint_path": str(downloaded_path),
+                }
+                if component_repo:
+                    default_steps, default_guidance = get_krea2_generation_defaults(component_repo)
+                    checkpoint_config.update(
+                        {
+                            "krea2_component_repo": component_repo,
+                            "steps": default_steps,
+                            "guidance_scale": default_guidance,
+                        }
+                    )
                 ctx.bot.config.set(
                     "models",
                     resource_name,
-                    value={
-                        "type": "civitai",
-                        "civitai_id": model_id,
-                        "civitai_version": version.id,
-                        "name": model.name,
-                        "base_model": version.base_model,
-                        "checkpoint_path": str(downloaded_path),
-                    },
+                    value=checkpoint_config,
                 )
 
                 embed = discord.Embed(
@@ -818,10 +947,31 @@ def register_commands(bot: "OneiroBot") -> None:
                 )
 
             # Add common fields
-            primary_file = version.primary_file
-            if primary_file:
-                size_mb = primary_file.size_kb / 1024
+            downloaded_file = selected_file or version.primary_file
+            if downloaded_file:
+                size_mb = downloaded_file.size_kb / 1024
                 embed.add_field(name="Size", value=f"{size_mb:.1f} MB", inline=True)
+            if selected_file:
+                embed.add_field(
+                    name="Precision",
+                    value=f"`{selected_precision}`",
+                    inline=True,
+                )
+            elif precision != "auto":
+                embed.add_field(
+                    name="Precision",
+                    value=f"`{precision}` ignored; selection is only supported for Krea 2 checkpoints",
+                    inline=False,
+                )
+            if not selected_file and krea2_variant != "auto":
+                embed.add_field(
+                    name="Krea 2 Variant",
+                    value=(
+                        f"`{krea2_variant}` ignored; component selection is only supported "
+                        "for Krea 2 checkpoints"
+                    ),
+                    inline=False,
+                )
 
             embed.set_footer(text=f"Civitai Model ID: {model_id} | Version: {version.id}")
 

--- a/src/oneiro/pipelines/civitai_checkpoint.py
+++ b/src/oneiro/pipelines/civitai_checkpoint.py
@@ -6,7 +6,8 @@ pipeline class based on CivitAI's baseModel metadata.
 """
 
 import math
-from dataclasses import dataclass
+import re
+from dataclasses import dataclass, replace
 from enum import StrEnum
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -87,6 +88,7 @@ class CivitaiBaseModel(StrEnum):
     # Other architectures
     Z_IMAGE = "Z-Image"
     Z_IMAGE_TURBO = "Z-Image Turbo"
+    KREA_2 = "Krea 2"
     PIXART_A = "PixArt a"
     PIXART_SIGMA = "PixArt Sigma"
     KOLORS = "Kolors"
@@ -427,6 +429,15 @@ CIVITAI_BASE_MODEL_PIPELINE_MAP: dict[str, PipelineConfig] = {
         default_height=1024,
         default_scheduler="default",
     ),
+    CivitaiBaseModel.KREA_2: PipelineConfig(
+        pipeline_class="Krea2Pipeline",
+        supports_negative_prompt=True,
+        default_steps=8,
+        default_guidance_scale=0.0,
+        default_width=1024,
+        default_height=1024,
+        default_scheduler="default",
+    ),
 }
 
 SCHEDULER_MAP: dict[str, tuple[str | None, dict[str, Any]]] = {
@@ -449,11 +460,24 @@ SCHEDULER_CHOICES: list[str] = list(SCHEDULER_MAP.keys())
 DEFAULT_SDXL_COMPONENT_REPO = "stabilityai/stable-diffusion-xl-base-1.0"
 DEFAULT_ZIMAGE_COMPONENT_REPO = "Tongyi-MAI/Z-Image-Turbo"
 DEFAULT_QWEN_COMPONENT_REPO = "Qwen/Qwen-Image"
+DEFAULT_KREA2_COMPONENT_REPO = "krea/Krea-2-Turbo"
+DEFAULT_KREA2_RAW_COMPONENT_REPO = "krea/Krea-2-Raw"
 DEFAULT_FLUX2_KLEIN_COMPONENT_REPO = "black-forest-labs/FLUX.2-klein-9B"
 DEFAULT_FLUX2_KLEIN_BASE_COMPONENT_REPO = "black-forest-labs/FLUX.2-klein-base-9B"
 DEFAULT_FLUX2_KLEIN_4B_COMPONENT_REPO = "black-forest-labs/FLUX.2-klein-4B"
 DEFAULT_FLUX2_KLEIN_4B_BASE_COMPONENT_REPO = "black-forest-labs/FLUX.2-klein-base-4B"
 COMFY_DIFFUSION_MODEL_PREFIX = "model.diffusion_model."
+KREA2_DTYPE_PRECISIONS = {
+    "BF16": "bf16",
+    "F16": "fp16",
+    "F32": "fp32",
+    "F64": "fp64",
+}
+KREA2_REQUIRED_TENSOR_KEYS = {
+    "first.weight",
+    "last.linear.weight",
+    "blocks.0.attn.wq.weight",
+}
 
 # Default fallback configuration
 DEFAULT_PIPELINE_CONFIG = PipelineConfig(
@@ -464,6 +488,69 @@ DEFAULT_PIPELINE_CONFIG = PipelineConfig(
     default_height=1024,
     default_scheduler="dpm++_karras",
 )
+
+
+def get_krea2_checkpoint_precision_from_header(header: dict[str, Any]) -> str:
+    """Validate a Krea SafeTensor header and return its dominant precision."""
+    metadata = header.get("__metadata__", {}) or {}
+    tensors = {key: value for key, value in header.items() if key != "__metadata__"}
+    if not isinstance(metadata, dict) or any(
+        not isinstance(value, dict) for value in tensors.values()
+    ):
+        raise ValueError("Invalid SafeTensor header")
+    source_keys = list(tensors)
+    dtypes = {str(value.get("dtype", "")) for value in tensors.values()}
+    if (
+        not source_keys
+        or "_quantization_metadata" in metadata
+        or any(key.endswith(".weight_scale") for key in source_keys)
+        or not dtypes.issubset(KREA2_DTYPE_PRECISIONS)
+    ):
+        raise ValueError("Quantized Krea 2 single-file checkpoints are not supported by Diffusers")
+    normalized_keys = {key.removeprefix(COMFY_DIFFUSION_MODEL_PREFIX) for key in source_keys}
+    if not KREA2_REQUIRED_TENSOR_KEYS.issubset(normalized_keys):
+        raise ValueError("SafeTensor file does not contain Krea 2 transformer weights")
+    element_counts = {
+        dtype: sum(
+            math.prod(value.get("shape", []))
+            for value in tensors.values()
+            if value.get("dtype") == dtype
+        )
+        for dtype in dtypes
+    }
+    dominant_dtype = max(
+        KREA2_DTYPE_PRECISIONS,
+        key=lambda dtype: element_counts.get(dtype, 0),
+    )
+    return KREA2_DTYPE_PRECISIONS[dominant_dtype]
+
+
+def _get_krea2_checkpoint_precision(checkpoint: Any) -> str:
+    """Validate an open Krea checkpoint and return its tensor precision."""
+    header: dict[str, Any] = {"__metadata__": checkpoint.metadata() or {}}
+    for key in checkpoint.keys():
+        tensor_slice = checkpoint.get_slice(key)
+        header[key] = {
+            "dtype": tensor_slice.get_dtype(),
+            "shape": tensor_slice.get_shape(),
+        }
+    return get_krea2_checkpoint_precision_from_header(header)
+
+
+def get_krea2_checkpoint_precision(checkpoint_path: Path) -> str:
+    """Read and validate Krea checkpoint precision from its SafeTensor header."""
+    from safetensors import safe_open
+
+    with safe_open(checkpoint_path, framework="pt", device="cpu") as checkpoint:
+        return _get_krea2_checkpoint_precision(checkpoint)
+
+
+def get_krea2_generation_defaults(component_repo: str) -> tuple[int, float]:
+    """Return the generation recipe for hosted Krea Raw or Turbo components."""
+    repo_name = component_repo.rsplit("/", 1)[-1]
+    if re.search(r"(?<![a-z])raw(?![a-z])", repo_name.lower()):
+        return 28, 4.5
+    return 8, 0.0
 
 
 def get_pipeline_config_for_base_model(base_model: str | None) -> PipelineConfig:
@@ -503,6 +590,9 @@ def get_pipeline_config_for_base_model(base_model: str | None) -> PipelineConfig
 
     if "qwen" in base_lower:
         return CIVITAI_BASE_MODEL_PIPELINE_MAP[CivitaiBaseModel.QWEN]
+
+    if "krea" in base_lower:
+        return CIVITAI_BASE_MODEL_PIPELINE_MAP[CivitaiBaseModel.KREA_2]
 
     if "sd 3.5" in base_lower or "sd3.5" in base_lower:
         if "turbo" in base_lower:
@@ -711,6 +801,14 @@ class CivitaiCheckpointPipeline(LoraLoaderMixin, EmbeddingLoaderMixin, BasePipel
             )
         else:
             self._pipeline_config = get_pipeline_config_for_base_model(base_model)
+            if self._pipeline_config.pipeline_class == "Krea2Pipeline":
+                component_repo = self._krea2_component_repo(model_config)
+                default_steps, default_guidance = get_krea2_generation_defaults(component_repo)
+                self._pipeline_config = replace(
+                    self._pipeline_config,
+                    default_steps=model_config.get("steps", default_steps),
+                    default_guidance_scale=model_config.get("guidance_scale", default_guidance),
+                )
 
         print(f"Loading checkpoint from {checkpoint_path}")
         print(f"  Base model: {base_model or 'unknown'}")
@@ -740,6 +838,7 @@ class CivitaiCheckpointPipeline(LoraLoaderMixin, EmbeddingLoaderMixin, BasePipel
         if self._pipeline_config.pipeline_class not in {
             "QwenImagePipeline",
             "Flux2KleinPipeline",
+            "Krea2Pipeline",
         }:
             pipeline_class = get_diffusers_pipeline_class(self._pipeline_config.pipeline_class)
 
@@ -798,6 +897,21 @@ class CivitaiCheckpointPipeline(LoraLoaderMixin, EmbeddingLoaderMixin, BasePipel
             if self._pipeline_config.pipeline_class == "Flux2KleinPipeline":
                 return self._load_flux2_klein_pipeline_from_single_file(
                     checkpoint_path, model_config
+                )
+            if self._pipeline_config.pipeline_class == "Krea2Pipeline":
+                from diffusers import Krea2Pipeline
+
+                component_repo = self._krea2_component_repo(model_config)
+                transformer_subfolder = model_config.get("transformer_subfolder", "transformer")
+                transformer = self._load_krea2_transformer_from_single_file(
+                    checkpoint_path,
+                    component_repo,
+                    transformer_subfolder,
+                )
+                return Krea2Pipeline.from_pretrained(
+                    component_repo,
+                    transformer=transformer,
+                    torch_dtype=self.policy.dtype,
                 )
 
         assert pipeline_class is not None
@@ -886,6 +1000,83 @@ class CivitaiCheckpointPipeline(LoraLoaderMixin, EmbeddingLoaderMixin, BasePipel
             torch_dtype=self.policy.dtype,
         )
 
+    def _load_krea2_transformer_from_single_file(
+        self,
+        checkpoint_path: Path,
+        component_repo: str,
+        transformer_subfolder: str,
+    ) -> Any:
+        """Stream a floating-point Comfy Krea checkpoint into a Diffusers transformer."""
+        from accelerate import init_empty_weights
+        from accelerate.utils import set_module_tensor_to_device
+        from diffusers import Krea2Transformer2DModel
+        from safetensors import safe_open
+
+        try:
+            transformer_config = Krea2Transformer2DModel.load_config(
+                component_repo,
+                subfolder=transformer_subfolder,
+            )
+        except OSError as error:
+            raise RuntimeError(
+                f"Unable to load Krea 2 components from '{component_repo}'; "
+                "accept its license on Hugging Face and set HF_TOKEN"
+            ) from error
+        with init_empty_weights():
+            transformer = Krea2Transformer2DModel.from_config(transformer_config)
+
+        expected_shapes = {
+            key: tuple(tensor.shape) for key, tensor in transformer.state_dict().items()
+        }
+        loaded_keys: set[str] = set()
+        keep_in_fp32_modules = set(transformer._keep_in_fp32_modules)
+
+        with safe_open(checkpoint_path, framework="pt", device="cpu") as checkpoint:
+            source_keys = list(checkpoint.keys())
+            _get_krea2_checkpoint_precision(checkpoint)
+
+            for source_key in source_keys:
+                tensor = checkpoint.get_tensor(source_key)
+                key, tensor = self._convert_krea2_checkpoint_tensor(source_key, tensor)
+                expected_shape = expected_shapes.get(key)
+                if expected_shape is None:
+                    raise ValueError(f"Unexpected Krea 2 checkpoint tensor: {source_key}")
+                if tuple(tensor.shape) != expected_shape:
+                    raise ValueError(
+                        f"Invalid shape for Krea 2 tensor {source_key}: "
+                        f"expected {expected_shape}, got {tuple(tensor.shape)}"
+                    )
+
+                set_module_tensor_to_device(
+                    transformer,
+                    key,
+                    "cpu",
+                    value=tensor,
+                    dtype=(
+                        torch.float32
+                        if keep_in_fp32_modules.intersection(key.split("."))
+                        else self.policy.dtype
+                    ),
+                )
+                loaded_keys.add(key)
+
+        missing_keys = expected_shapes.keys() - loaded_keys
+        if missing_keys:
+            missing = ", ".join(sorted(missing_keys)[:3])
+            raise ValueError(f"Krea 2 checkpoint is missing tensors: {missing}")
+
+        return transformer
+
+    @staticmethod
+    def _krea2_component_repo(model_config: dict[str, Any]) -> str:
+        """Return the hosted component repository for a Krea checkpoint."""
+        return (
+            model_config.get("krea2_component_repo")
+            or model_config.get("component_repo")
+            or model_config.get("repo")
+            or DEFAULT_KREA2_COMPONENT_REPO
+        )
+
     def _load_transformer_checkpoint(self, checkpoint_path: Path) -> dict[str, Any]:
         """Load and normalize CivitAI/Comfy transformer checkpoint keys for Diffusers.
 
@@ -911,6 +1102,51 @@ class CivitaiCheckpointPipeline(LoraLoaderMixin, EmbeddingLoaderMixin, BasePipel
             normalized_checkpoint[normalized_key] = tensor
 
         return normalized_checkpoint
+
+    @staticmethod
+    def _convert_krea2_checkpoint_tensor(
+        key: str,
+        tensor: torch.Tensor,
+    ) -> tuple[str, torch.Tensor]:
+        """Convert one Comfy Krea 2 tensor to its Diffusers name and shape."""
+        key = key.removeprefix(COMFY_DIFFUSION_MODEL_PREFIX)
+        prefix_replacements = (
+            ("first.", "img_in."),
+            ("tmlp.0.", "time_embed.linear_1."),
+            ("tmlp.2.", "time_embed.linear_2."),
+            ("tproj.1.", "time_mod_proj."),
+            ("txtmlp.0.scale", "txt_in.norm.weight"),
+            ("txtmlp.1.", "txt_in.linear_1."),
+            ("txtmlp.3.", "txt_in.linear_2."),
+            ("txtfusion.", "text_fusion."),
+            ("blocks.", "transformer_blocks."),
+            ("last.modulation.lin", "final_layer.scale_shift_table"),
+            ("last.norm.scale", "final_layer.norm.weight"),
+            ("last.linear.", "final_layer.linear."),
+        )
+        for source, target in prefix_replacements:
+            if key.startswith(source):
+                key = target + key.removeprefix(source)
+                break
+
+        key = key.replace(".attn.qknorm.qnorm.scale", ".attn.norm_q.weight")
+        key = key.replace(".attn.qknorm.knorm.scale", ".attn.norm_k.weight")
+        key = key.replace(".prenorm.scale", ".norm1.weight")
+        key = key.replace(".postnorm.scale", ".norm2.weight")
+        key = key.replace(".attn.wq.", ".attn.to_q.")
+        key = key.replace(".attn.wk.", ".attn.to_k.")
+        key = key.replace(".attn.wv.", ".attn.to_v.")
+        key = key.replace(".attn.gate.", ".attn.to_gate.")
+        key = key.replace(".attn.wo.", ".attn.to_out.0.")
+        key = key.replace(".mlp.", ".ff.")
+
+        if key == "final_layer.scale_shift_table":
+            tensor = tensor.reshape(2, -1)
+        elif key.endswith(".mod.lin"):
+            key = key.removesuffix(".mod.lin") + ".scale_shift_table"
+            tensor = tensor.reshape(6, -1)
+
+        return key, tensor
 
     def _resolve_qwen_transformer_dtype(
         self,
@@ -1287,6 +1523,13 @@ class CivitaiCheckpointPipeline(LoraLoaderMixin, EmbeddingLoaderMixin, BasePipel
             as the actual seed used, prompts, final image size, number of
             steps, and guidance scale.
         """
+        if (
+            self._pipeline_config is not None
+            and self._pipeline_config.pipeline_class == "Krea2Pipeline"
+            and (kwargs.get("init_image") is not None or kwargs.get("mask_image") is not None)
+        ):
+            raise ValueError("Krea 2 supports text-to-image only")
+
         # Apply defaults from pipeline config (validation happens in super().generate())
         # Note: We need to check _pipeline_config here before applying defaults,
         # but full validation happens in validate_pipeline() called by super()

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -1,8 +1,17 @@
 """Tests for bot helper functions."""
 
+from unittest.mock import AsyncMock, MagicMock, patch
+
 import pytest
 
-from oneiro.discord.commands import slugify
+from oneiro.civitai import ModelVersion
+from oneiro.discord.commands import (
+    is_krea2_base_model,
+    krea2_component_repo,
+    register_commands,
+    slugify,
+)
+from oneiro.queue import QueueStatus
 from oneiro.services.generation import (
     MAX_LORA_WEIGHT,
     MIN_LORA_WEIGHT,
@@ -38,6 +47,203 @@ class TestSlugify:
     def test_only_special_chars_returns_unnamed(self):
         """String with only special chars returns 'unnamed'."""
         assert slugify("!!!@@@") == "unnamed"
+
+
+@pytest.mark.parametrize(
+    ("base_model", "expected"),
+    [
+        ("Krea 2", True),
+        ("Krea-2", True),
+        ("Krea2", True),
+        ("Krea 2 Turbo", True),
+        ("Flux.1 Krea", False),
+        (None, False),
+    ],
+)
+def test_is_krea2_base_model_uses_pipeline_resolution(base_model, expected):
+    """Fetch precision selection uses the same architecture resolution as model loading."""
+    assert is_krea2_base_model(base_model) is expected
+
+
+@pytest.mark.parametrize(
+    ("model_name", "version_name", "expected"),
+    [
+        ("Krea 2 Raw", "v1", "krea/Krea-2-Raw"),
+        ("Krea 2", "raw v1", "krea/Krea-2-Raw"),
+        ("Krea 2 Turbo", "v1", "krea/Krea-2-Turbo"),
+        ("Krea 2 Turbo Raw", "v1 Turbo", "krea/Krea-2-Turbo"),
+    ],
+)
+def test_krea2_component_repo_follows_civitai_names(model_name, version_name, expected):
+    """Fetched Krea checkpoints carry the matching hosted component recipe."""
+    assert krea2_component_repo(model_name, version_name) == expected
+
+
+@pytest.mark.parametrize(
+    ("checkpoint_kind", "writes_config"),
+    [
+        ("krea", True),
+        ("quantized", False),
+        ("lora", False),
+        ("malformed", False),
+        ("cached", True),
+        ("cached_malformed", False),
+    ],
+)
+async def test_fetch_krea2_validates_header_before_writing_config(
+    checkpoint_kind, writes_config, tmp_path
+):
+    """Fetch persists only validated Krea checkpoints and reports header precision."""
+    commands = {}
+    bot = MagicMock()
+
+    def slash_command(**kwargs):
+        def register(command):
+            commands[kwargs["name"]] = command
+            return command
+
+        return register
+
+    bot.slash_command.side_effect = slash_command
+    register_commands(bot)
+
+    version = ModelVersion.from_dict(
+        {
+            "id": 2,
+            "modelId": 1,
+            "name": "v1 Turbo",
+            "baseModel": "Krea 2",
+            "files": [
+                {
+                    "id": 3,
+                    "name": "krea.safetensors",
+                    "type": "Model",
+                    "downloadUrl": "https://civitai.com/download/3",
+                    "metadata": {"format": "SafeTensor", "fp": "bf16"},
+                    "hashes": {"SHA256": "ABC123"},
+                    "primary": True,
+                }
+            ],
+        }
+    )
+    model = MagicMock()
+    model.name = "Krea 2 Turbo Raw"
+    model.type = "Checkpoint"
+    model.latest_version = version
+    model.versions = [version]
+
+    status = MagicMock()
+    status.edit = AsyncMock()
+    ctx = MagicMock()
+    ctx.defer = AsyncMock()
+    ctx.followup.send = AsyncMock(return_value=status)
+    ctx.bot.config.state_path = "state.toml"
+    ctx.bot.config.get.return_value = {}
+    ctx.bot.config.set = MagicMock()
+    ctx.bot.pipeline_manager = None
+    ctx.bot.civitai_client.get_model = AsyncMock(return_value=model)
+    downloaded_path = tmp_path / "krea.safetensors"
+    import torch
+    from safetensors.torch import save_file
+
+    dtype = torch.int8 if checkpoint_kind == "quantized" else torch.bfloat16
+    malformed = checkpoint_kind in {"malformed", "cached_malformed"}
+    tensors = (
+        {
+            "first.weight": torch.ones(1, dtype=dtype),
+            "last.linear.weight": torch.ones(1, dtype=dtype),
+            "blocks.0.attn.wq.weight": torch.ones(1, dtype=dtype),
+        }
+        if checkpoint_kind != "lora"
+        else {"lora_unet_blocks_0_attn_wq.alpha": torch.ones(1, dtype=torch.float16)}
+    )
+    if malformed:
+        downloaded_path.write_bytes(b"not a safetensor")
+    elif checkpoint_kind == "lora":
+        save_file(tensors, downloaded_path)
+    elif checkpoint_kind == "krea":
+        tensors["last.norm.scale"] = torch.ones(1, dtype=torch.float32)
+        save_file(tensors, downloaded_path)
+    else:
+        save_file(tensors, downloaded_path)
+
+    header_kind = "krea" if malformed or checkpoint_kind == "cached" else checkpoint_kind
+    header_dtype = "I8" if header_kind == "quantized" else "BF16"
+    header_keys = (
+        ["lora_unet_blocks_0_attn_wq.alpha"]
+        if header_kind == "lora"
+        else ["first.weight", "last.linear.weight", "blocks.0.attn.wq.weight"]
+    )
+    ctx.bot.civitai_client.get_safetensor_header = AsyncMock(
+        return_value={
+            key: {"dtype": header_dtype, "shape": [1], "data_offsets": [0, 2]}
+            for key in header_keys
+        }
+    )
+    ctx.bot.civitai_client.cache.get.return_value = (
+        downloaded_path if checkpoint_kind.startswith("cached") else None
+    )
+    ctx.bot.civitai_client.download_model_version = AsyncMock(return_value=downloaded_path)
+
+    with patch("oneiro.discord.commands.DevicePolicy.auto_detect") as auto_detect:
+        auto_detect.return_value.dtype = "bfloat16"
+        await commands["fetch"](
+            ctx,
+            "https://civitai.com/models/1",
+            krea2_variant="raw",
+        )
+
+    assert ctx.bot.config.set.called is writes_config
+    if writes_config:
+        ctx.bot.civitai_client.download_model_version.assert_awaited_once()
+        if checkpoint_kind == "cached":
+            ctx.bot.civitai_client.get_safetensor_header.assert_not_awaited()
+        else:
+            ctx.bot.civitai_client.get_safetensor_header.assert_awaited_once()
+        checkpoint_config = ctx.bot.config.set.call_args.kwargs["value"]
+        assert checkpoint_config["krea2_component_repo"] == "krea/Krea-2-Raw"
+        assert checkpoint_config["steps"] == 28
+        assert checkpoint_config["guidance_scale"] == 4.5
+        embed = status.edit.call_args.kwargs["embed"]
+        assert next(field.value for field in embed.fields if field.name == "Precision") == "`bf16`"
+
+        ctx.bot.pipeline_manager = MagicMock(current_model="fetched-krea")
+        ctx.bot.content_filter = None
+        ctx.bot.config.get.side_effect = lambda *keys, default=None: (
+            checkpoint_config if keys == ("models", "fetched-krea") else {}
+        )
+        queue_result = MagicMock(status=QueueStatus.QUEUED, position=1)
+        ctx.bot.generation_queue.add = MagicMock(return_value=queue_result)
+        ctx.author.id = 1
+        lora_result = MagicMock(configs=[], warnings=[], auto_detected=False)
+
+        with (
+            patch(
+                "oneiro.discord.commands.resolve_loras",
+                new=AsyncMock(return_value=lora_result),
+            ),
+            patch(
+                "oneiro.discord.commands.create_dream_callbacks",
+                return_value=(MagicMock(), MagicMock(), MagicMock()),
+            ),
+        ):
+            await commands["dream"](ctx, "test prompt")
+
+        request = ctx.bot.generation_queue.add.call_args.kwargs["request"]
+        assert request["steps"] == 28
+        assert request["guidance_scale"] == 4.5
+    elif checkpoint_kind in {"quantized", "lora"}:
+        ctx.bot.civitai_client.download_model_version.assert_not_awaited()
+        ctx.bot.civitai_client.get_safetensor_header.assert_awaited_once()
+    else:
+        if checkpoint_kind == "cached_malformed":
+            ctx.bot.civitai_client.download_model_version.assert_not_awaited()
+            ctx.bot.civitai_client.get_safetensor_header.assert_not_awaited()
+        else:
+            ctx.bot.civitai_client.download_model_version.assert_awaited_once()
+            ctx.bot.civitai_client.get_safetensor_header.assert_awaited_once()
+        assert not downloaded_path.exists()
+        ctx.bot.civitai_client.cache.remove.assert_called_once_with("ABC123")
 
 
 class TestValidateLoraWeight:

--- a/tests/test_civitai.py
+++ b/tests/test_civitai.py
@@ -11,6 +11,7 @@ from oneiro.civitai import (
     CivitaiAuthError,
     CivitaiCache,
     CivitaiClient,
+    CivitaiError,
     CivitaiNotFoundError,
     CivitaiRateLimitError,
     Model,
@@ -199,6 +200,125 @@ class TestModelVersion:
 
         assert version.primary_file is not None
         assert version.primary_file.name == "first.bin"
+
+    def test_select_checkpoint_file_auto_prefers_diffusers_compatible_precision(self):
+        """Automatic checkpoint selection skips unsupported quantized files."""
+        version = ModelVersion.from_dict(
+            {
+                "id": 1,
+                "name": "Krea",
+                "files": [
+                    {
+                        "id": 1,
+                        "name": "krea.safetensors",
+                        "downloadUrl": "http://x/fp8",
+                        "metadata": {"format": "SafeTensor", "fp": "fp8"},
+                        "primary": True,
+                    },
+                    {
+                        "id": 2,
+                        "name": "krea.safetensors",
+                        "downloadUrl": "http://x/bf16",
+                        "metadata": {"format": "SafeTensor", "fp": "bf16"},
+                    },
+                ],
+            }
+        )
+
+        selected = version.select_checkpoint_file()
+
+        assert selected.id == 2
+
+    def test_select_checkpoint_file_honors_explicit_precision(self):
+        """Explicit checkpoint precision overrides the automatic ranking."""
+        version = ModelVersion.from_dict(
+            {
+                "id": 1,
+                "name": "Krea",
+                "files": [
+                    {
+                        "id": 1,
+                        "name": "krea-bf16.safetensors",
+                        "downloadUrl": "http://x/bf16",
+                        "metadata": {"format": "SafeTensor", "fp": "bf16"},
+                        "primary": True,
+                    },
+                    {
+                        "id": 2,
+                        "name": "krea-fp16.safetensors",
+                        "downloadUrl": "http://x/fp16",
+                        "metadata": {"format": "SafeTensor", "fp": "fp16"},
+                    },
+                ],
+            }
+        )
+
+        selected = version.select_checkpoint_file("fp16")
+
+        assert selected.id == 2
+
+    def test_select_checkpoint_file_auto_prefers_policy_precision(self):
+        """Automatic checkpoint selection follows the resolved device policy dtype."""
+        version = ModelVersion.from_dict(
+            {
+                "id": 1,
+                "name": "Krea",
+                "files": [
+                    {
+                        "id": 1,
+                        "name": "krea-bf16.safetensors",
+                        "downloadUrl": "http://x/bf16",
+                        "metadata": {"format": "SafeTensor", "fp": "bf16"},
+                    },
+                    {
+                        "id": 2,
+                        "name": "krea-fp16.safetensors",
+                        "downloadUrl": "http://x/fp16",
+                        "metadata": {"format": "SafeTensor", "fp": "fp16"},
+                    },
+                ],
+            }
+        )
+
+        selected = version.select_checkpoint_file(preferred_precision="fp16")
+
+        assert selected.id == 2
+
+    def test_select_checkpoint_file_reports_unavailable_precision_as_civitai_error(self):
+        """Unavailable checkpoint precision is not reported as a URL parsing failure."""
+        version = ModelVersion.from_dict(SAMPLE_VERSION_RESPONSE)
+
+        with pytest.raises(CivitaiError, match="No fp32 SafeTensor checkpoint found"):
+            version.select_checkpoint_file("fp32")
+
+    def test_select_checkpoint_file_never_returns_vae(self):
+        """Floating-point VAE siblings are not mistaken for transformer checkpoints."""
+        version = ModelVersion.from_dict(
+            {
+                "id": 1,
+                "name": "Krea",
+                "files": [
+                    {
+                        "id": 1,
+                        "name": "krea-fp8.safetensors",
+                        "type": "Model",
+                        "downloadUrl": "http://x/model",
+                        "metadata": {"format": "SafeTensor", "fp": "fp8"},
+                        "primary": True,
+                    },
+                    {
+                        "id": 2,
+                        "name": "vae.safetensors",
+                        "type": "VAE",
+                        "downloadUrl": "http://x/vae",
+                        "metadata": {"format": "SafeTensor", "fp": "bf16"},
+                    },
+                ],
+            }
+        )
+
+        with pytest.raises(CivitaiError, match="No Diffusers-compatible"):
+            version.select_checkpoint_file()
 
 
 class TestModel:
@@ -676,6 +796,90 @@ class TestCivitaiClientDownload:
         assert progress_calls[-1][0] == progress_calls[-1][1]
 
     @respx.mock
+    async def test_get_safetensor_header_uses_two_ranged_requests(self, tmp_path):
+        """SafeTensor metadata is read without transferring the tensor payload."""
+        import torch
+        from safetensors.torch import save_file
+
+        checkpoint = tmp_path / "krea.safetensors"
+        save_file({"first.weight": torch.ones(4, dtype=torch.bfloat16)}, checkpoint)
+        contents = checkpoint.read_bytes()
+        header_size = int.from_bytes(contents[:8], "little")
+        route = respx.get("https://civitai.com/api/download/models/1")
+        route.side_effect = [
+            httpx.Response(
+                206,
+                content=contents[:8],
+                headers={"Content-Range": f"bytes 0-7/{len(contents)}"},
+            ),
+            httpx.Response(
+                206,
+                content=contents[: 8 + header_size],
+                headers={"Content-Range": f"bytes 0-{7 + header_size}/{len(contents)}"},
+            ),
+        ]
+
+        async with CivitaiClient(cache_dir=tmp_path) as client:
+            header = await client.get_safetensor_header("https://civitai.com/api/download/models/1")
+
+        assert header["first.weight"]["dtype"] == "BF16"
+        assert [call.request.headers["Range"] for call in route.calls] == [
+            "bytes=0-7",
+            f"bytes=0-{7 + header_size}",
+        ]
+        assert all(call.request.headers["Accept-Encoding"] == "identity" for call in route.calls)
+
+    @respx.mock
+    async def test_get_safetensor_header_rejects_oversized_header(self, tmp_path):
+        """Remote header size is bounded before the JSON payload is requested."""
+        route = respx.get("https://civitai.com/api/download/models/1").mock(
+            return_value=httpx.Response(
+                206,
+                content=(1_000_001).to_bytes(8, "little"),
+                headers={"Content-Range": "bytes 0-7/1000009"},
+            )
+        )
+
+        async with CivitaiClient(cache_dir=tmp_path) as client:
+            with pytest.raises(CivitaiError, match="Invalid SafeTensor header size"):
+                await client.get_safetensor_header("https://civitai.com/api/download/models/1")
+
+        assert route.call_count == 1
+
+    @respx.mock
+    async def test_get_safetensor_header_rejects_invalid_descriptor(self, tmp_path):
+        """Preflight rejects malformed tensor descriptors before downloading weights."""
+        import json
+
+        header = json.dumps(
+            {
+                "first.weight": {
+                    "dtype": "BF16",
+                    "shape": "invalid",
+                    "data_offsets": [0, 2],
+                }
+            }
+        ).encode()
+        contents = len(header).to_bytes(8, "little") + header
+        route = respx.get("https://civitai.com/api/download/models/1")
+        route.side_effect = [
+            httpx.Response(
+                206,
+                content=contents[:8],
+                headers={"Content-Range": f"bytes 0-7/{len(contents)}"},
+            ),
+            httpx.Response(
+                206,
+                content=contents,
+                headers={"Content-Range": f"bytes 0-{len(contents) - 1}/{len(contents)}"},
+            ),
+        ]
+
+        async with CivitaiClient(cache_dir=tmp_path) as client:
+            with pytest.raises(CivitaiError, match="Invalid SafeTensor tensor descriptor"):
+                await client.get_safetensor_header("https://civitai.com/api/download/models/1")
+
+    @respx.mock
     async def test_download_uses_cache(self, tmp_path):
         """download_file returns cached file if hash matches."""
         # Create cached file
@@ -723,3 +927,80 @@ class TestCivitaiClientDownload:
 
         assert result.name == "test_model.safetensors"
         assert result.read_bytes() == test_content
+
+    @respx.mock
+    async def test_download_model_version_keeps_duplicate_precisions_separate(self, tmp_path):
+        """Checkpoint variants with the same source name cannot overwrite each other."""
+        respx.get("https://civitai.com/api/download/models/2").mock(
+            return_value=httpx.Response(200, content=b"fp16")
+        )
+        version = ModelVersion.from_dict(
+            {
+                "id": 1,
+                "name": "Krea",
+                "files": [
+                    {
+                        "id": 1,
+                        "name": "krea.safetensors",
+                        "downloadUrl": "https://civitai.com/api/download/models/1",
+                        "metadata": {"format": "SafeTensor", "fp": "bf16"},
+                        "primary": True,
+                    },
+                    {
+                        "id": 2,
+                        "name": "krea.safetensors",
+                        "downloadUrl": "https://civitai.com/api/download/models/2",
+                        "metadata": {"format": "SafeTensor", "fp": "fp16"},
+                    },
+                ],
+            }
+        )
+        selected = version.select_checkpoint_file("fp16")
+
+        async with CivitaiClient(cache_dir=tmp_path, verify_hashes=False) as client:
+            result = await client.download_model_version(version, model_file=selected)
+
+        assert result.name == "krea-fp16-2.safetensors"
+        assert result.read_bytes() == b"fp16"
+
+    @respx.mock
+    async def test_download_model_version_ids_prevent_cross_version_overwrite(self, tmp_path):
+        """Identical filenames from separate versions use distinct cache paths."""
+        respx.get("https://civitai.com/api/download/models/1").mock(
+            return_value=httpx.Response(200, content=b"first")
+        )
+        respx.get("https://civitai.com/api/download/models/2").mock(
+            return_value=httpx.Response(200, content=b"second")
+        )
+
+        def version(version_id, file_id, download_url):
+            return ModelVersion.from_dict(
+                {
+                    "id": version_id,
+                    "name": "Krea",
+                    "files": [
+                        {
+                            "id": file_id,
+                            "name": "model.safetensors",
+                            "downloadUrl": download_url,
+                            "metadata": {"format": "SafeTensor", "fp": "bf16"},
+                            "primary": True,
+                        }
+                    ],
+                }
+            )
+
+        async with CivitaiClient(cache_dir=tmp_path, verify_hashes=False) as client:
+            first_version = version(1, 101, "https://civitai.com/api/download/models/1")
+            second_version = version(2, 202, "https://civitai.com/api/download/models/2")
+            first = await client.download_model_version(
+                first_version, model_file=first_version.primary_file
+            )
+            second = await client.download_model_version(
+                second_version, model_file=second_version.primary_file
+            )
+
+        assert first.name == "model-bf16-101.safetensors"
+        assert second.name == "model-bf16-202.safetensors"
+        assert first.read_bytes() == b"first"
+        assert second.read_bytes() == b"second"

--- a/tests/test_civitai_checkpoint.py
+++ b/tests/test_civitai_checkpoint.py
@@ -15,6 +15,7 @@ from oneiro.pipelines.civitai_checkpoint import (
     CivitaiCheckpointPipeline,
     PipelineConfig,
     get_diffusers_pipeline_class,
+    get_krea2_checkpoint_precision,
     get_pipeline_config_for_base_model,
 )
 from oneiro.pipelines.lora import LoraConfig, LoraSource
@@ -90,6 +91,22 @@ class TestGetPipelineConfigForBaseModel:
         assert config.supports_negative_prompt is False
         assert config.default_steps == 4
         assert config.default_guidance_scale == 1.0
+
+    def test_exact_match_krea2(self):
+        """CivitAI Krea 2 checkpoints use the Krea pipeline."""
+        config = get_pipeline_config_for_base_model("Krea 2")
+
+        assert config.pipeline_class == "Krea2Pipeline"
+        assert config.supports_negative_prompt is True
+        assert config.default_steps == 8
+        assert config.default_guidance_scale == 0.0
+
+    @pytest.mark.parametrize("base_model", ["Krea-2", "Krea2", "Krea 2 Turbo"])
+    def test_partial_match_krea2(self, base_model):
+        """CivitAI Krea spelling variants use the Krea pipeline."""
+        config = get_pipeline_config_for_base_model(base_model)
+
+        assert config.pipeline_class == "Krea2Pipeline"
 
     def test_partial_match_flux(self):
         """Partial match for Flux variants."""
@@ -946,12 +963,458 @@ class TestCivitaiCheckpointPipelineLoad:
             torch_dtype=torch.bfloat16,
         )
 
+    def test_load_krea2_single_file_assembles_krea_pipeline(self, tmp_path):
+        """CivitAI Krea checkpoints replace the transformer in the hosted pipeline."""
+        checkpoint = tmp_path / "krea2.safetensors"
+        checkpoint.write_bytes(b"dummy")
+        mock_pipe = MagicMock()
+        mock_transformer = MagicMock()
+        mock_policy = DevicePolicy(device="cpu", dtype=torch.bfloat16, offload=OffloadMode.NEVER)
+
+        with (
+            patch.object(CivitaiCheckpointPipeline, "configure_scheduler"),
+            patch.object(DevicePolicy, "auto_detect", return_value=mock_policy),
+            patch.object(
+                CivitaiCheckpointPipeline,
+                "_load_krea2_transformer_from_single_file",
+                create=True,
+                return_value=mock_transformer,
+            ) as mock_load_transformer,
+            patch(
+                "oneiro.pipelines.civitai_checkpoint.get_diffusers_pipeline_class"
+            ) as mock_get_class,
+            patch("diffusers.Krea2Pipeline") as mock_krea2_pipeline,
+        ):
+            mock_krea2_pipeline.from_pretrained.return_value = mock_pipe
+
+            pipeline = CivitaiCheckpointPipeline()
+            pipeline.load(
+                {
+                    "checkpoint_path": str(checkpoint),
+                    "base_model": "Krea 2",
+                }
+            )
+
+        mock_get_class.assert_not_called()
+        mock_load_transformer.assert_called_once_with(
+            checkpoint,
+            "krea/Krea-2-Turbo",
+            "transformer",
+        )
+        mock_krea2_pipeline.from_pretrained.assert_called_once_with(
+            "krea/Krea-2-Turbo",
+            transformer=mock_transformer,
+            torch_dtype=torch.bfloat16,
+        )
+
+    @pytest.mark.parametrize(
+        ("component_repo", "expected_steps", "expected_guidance"),
+        [
+            ("krea/Krea-2-Raw", 28, 4.5),
+            ("drawthings/krea2-turbo", 8, 0.0),
+        ],
+    )
+    def test_load_krea2_component_repo_uses_matching_defaults(
+        self,
+        tmp_path,
+        component_repo,
+        expected_steps,
+        expected_guidance,
+    ):
+        """Krea component model names, not organization names, select the recipe."""
+        checkpoint = tmp_path / "krea2-raw.safetensors"
+        checkpoint.write_bytes(b"dummy")
+        mock_transformer = MagicMock()
+        mock_policy = DevicePolicy(device="cpu", dtype=torch.bfloat16, offload=OffloadMode.NEVER)
+
+        with (
+            patch.object(CivitaiCheckpointPipeline, "configure_scheduler"),
+            patch.object(DevicePolicy, "auto_detect", return_value=mock_policy),
+            patch.object(
+                CivitaiCheckpointPipeline,
+                "_load_krea2_transformer_from_single_file",
+                return_value=mock_transformer,
+            ),
+            patch("diffusers.Krea2Pipeline") as mock_krea2_pipeline,
+        ):
+            mock_krea2_pipeline.from_pretrained.return_value = MagicMock()
+            pipeline = CivitaiCheckpointPipeline()
+            pipeline.load(
+                {
+                    "checkpoint_path": str(checkpoint),
+                    "base_model": "Krea 2",
+                    "krea2_component_repo": component_repo,
+                }
+            )
+
+        assert pipeline.pipeline_config is not None
+        assert pipeline.pipeline_config.default_steps == expected_steps
+        assert pipeline.pipeline_config.default_guidance_scale == expected_guidance
+        mock_krea2_pipeline.from_pretrained.assert_called_once_with(
+            component_repo,
+            transformer=mock_transformer,
+            torch_dtype=torch.bfloat16,
+        )
+
+    def test_get_krea2_checkpoint_precision_rejects_quantized_tensor_header(self, tmp_path):
+        """Tensor dtypes override incorrect floating-point CivitAI metadata."""
+        from safetensors.torch import save_file
+
+        checkpoint = tmp_path / "mislabeled-bf16.safetensors"
+        save_file(
+            {
+                "first.weight": torch.ones(2, dtype=torch.int8),
+                "last.linear.weight": torch.ones(2, dtype=torch.int8),
+                "blocks.0.attn.wq.weight": torch.ones(2, dtype=torch.int8),
+            },
+            checkpoint,
+        )
+
+        with pytest.raises(ValueError, match="Quantized Krea 2"):
+            get_krea2_checkpoint_precision(checkpoint)
+
+    def test_get_krea2_checkpoint_precision_reads_tensor_header(self, tmp_path):
+        """Displayed checkpoint precision comes from the SafeTensor header."""
+        from safetensors.torch import save_file
+
+        checkpoint = tmp_path / "mislabeled-fp16.safetensors"
+        save_file(
+            {
+                "model.diffusion_model.first.weight": torch.ones(2, dtype=torch.bfloat16),
+                "model.diffusion_model.last.linear.weight": torch.ones(2, dtype=torch.bfloat16),
+                "model.diffusion_model.blocks.0.attn.wq.weight": torch.ones(
+                    2, dtype=torch.bfloat16
+                ),
+            },
+            checkpoint,
+        )
+
+        assert get_krea2_checkpoint_precision(checkpoint) == "bf16"
+
+    def test_get_krea2_checkpoint_precision_reports_dominant_weight_dtype(self, tmp_path):
+        """FP32 norms do not make a BF16 checkpoint report compound precision."""
+        from safetensors.torch import save_file
+
+        checkpoint = tmp_path / "mixed.safetensors"
+        save_file(
+            {
+                "first.weight": torch.ones(100, dtype=torch.bfloat16),
+                "last.linear.weight": torch.ones(100, dtype=torch.bfloat16),
+                "blocks.0.attn.wq.weight": torch.ones(100, dtype=torch.bfloat16),
+                "last.norm.scale": torch.ones(10, dtype=torch.float32),
+            },
+            checkpoint,
+        )
+
+        assert get_krea2_checkpoint_precision(checkpoint) == "bf16"
+
+    def test_get_krea2_checkpoint_precision_rejects_quantization_metadata(self, tmp_path):
+        """Quantization metadata is rejected even when every tensor claims BF16."""
+        from safetensors.torch import save_file
+
+        checkpoint = tmp_path / "quantized-bf16.safetensors"
+        save_file(
+            {
+                "first.weight": torch.ones(2, dtype=torch.bfloat16),
+                "last.linear.weight": torch.ones(2, dtype=torch.bfloat16),
+                "blocks.0.attn.wq.weight": torch.ones(2, dtype=torch.bfloat16),
+            },
+            checkpoint,
+            metadata={"_quantization_metadata": "{}"},
+        )
+
+        with pytest.raises(ValueError, match="Quantized Krea 2"):
+            get_krea2_checkpoint_precision(checkpoint)
+
+    def test_load_krea2_transformer_uses_policy_dtype_and_keeps_norms_fp32(self, tmp_path):
+        """Krea weights follow the policy while declared norm modules remain FP32."""
+        from safetensors.torch import save_file
+
+        checkpoint = tmp_path / "krea2.safetensors"
+        source_weight = torch.arange(8, dtype=torch.float32).reshape(4, 2)
+        source_bias = torch.arange(4, dtype=torch.float32)
+        source_norm = torch.arange(4, dtype=torch.float32)
+        source_linear = torch.arange(8, dtype=torch.float32).reshape(4, 2)
+        source_query = torch.arange(8, dtype=torch.float32).reshape(4, 2)
+        save_file(
+            {
+                "first.weight": source_weight,
+                "first.bias": source_bias,
+                "last.norm.scale": source_norm,
+                "last.linear.weight": source_linear,
+                "blocks.0.attn.wq.weight": source_query,
+            },
+            checkpoint,
+        )
+
+        with torch.device("meta"):
+            transformer = torch.nn.Module()
+            transformer.img_in = torch.nn.Linear(2, 4)
+            transformer.final_layer = torch.nn.Module()
+            transformer.final_layer.norm = torch.nn.LayerNorm(4, bias=False)
+            transformer.final_layer.linear = torch.nn.Linear(2, 4, bias=False)
+            block = torch.nn.Module()
+            block.attn = torch.nn.Module()
+            block.attn.to_q = torch.nn.Linear(2, 4, bias=False)
+            transformer.transformer_blocks = torch.nn.ModuleList([block])
+        transformer._keep_in_fp32_modules = ["norm", "norm1", "norm2", "norm_q", "norm_k"]
+
+        pipeline = CivitaiCheckpointPipeline()
+        pipeline.policy = DevicePolicy(
+            device="cpu",
+            dtype=torch.bfloat16,
+            offload=OffloadMode.NEVER,
+        )
+
+        with patch("diffusers.Krea2Transformer2DModel") as mock_transformer_class:
+            mock_transformer_class.load_config.return_value = {"test": True}
+            mock_transformer_class.from_config.return_value = transformer
+
+            result = pipeline._load_krea2_transformer_from_single_file(
+                checkpoint,
+                "krea/Krea-2-Turbo",
+                "transformer",
+            )
+
+        assert result is transformer
+        assert result.img_in.weight.device.type == "cpu"
+        assert result.img_in.weight.dtype == torch.bfloat16
+        assert result.img_in.bias.dtype == torch.bfloat16
+        assert result.final_layer.norm.weight.dtype == torch.float32
+        assert torch.equal(result.img_in.weight, source_weight.to(torch.bfloat16))
+        assert torch.equal(result.img_in.bias, source_bias.to(torch.bfloat16))
+        assert torch.equal(result.final_layer.norm.weight, source_norm)
+
+    def test_load_krea2_transformer_rejects_quantized_checkpoint(self, tmp_path):
+        """Comfy quantization is rejected instead of being silently dequantized."""
+        from safetensors.torch import save_file
+
+        fp8_dtype = getattr(torch, "float8_e4m3fn", None)
+        if fp8_dtype is None:
+            pytest.skip("torch build does not expose float8_e4m3fn")
+
+        checkpoint = tmp_path / "krea2-fp8.safetensors"
+        save_file(
+            {
+                "first.weight": torch.zeros((4, 2), dtype=fp8_dtype),
+                "first.bias": torch.zeros(4),
+            },
+            checkpoint,
+            metadata={"_quantization_metadata": "{}"},
+        )
+        with torch.device("meta"):
+            transformer = torch.nn.Module()
+            transformer.img_in = torch.nn.Linear(2, 4)
+        transformer._keep_in_fp32_modules = ["norm", "norm1", "norm2", "norm_q", "norm_k"]
+
+        pipeline = CivitaiCheckpointPipeline()
+        pipeline.policy = DevicePolicy(
+            device="cpu",
+            dtype=torch.bfloat16,
+            offload=OffloadMode.NEVER,
+        )
+
+        with (
+            patch("diffusers.Krea2Transformer2DModel") as mock_transformer_class,
+            pytest.raises(ValueError, match="Quantized Krea 2 single-file checkpoints"),
+        ):
+            mock_transformer_class.load_config.return_value = {"test": True}
+            mock_transformer_class.from_config.return_value = transformer
+            pipeline._load_krea2_transformer_from_single_file(
+                checkpoint,
+                "krea/Krea-2-Turbo",
+                "transformer",
+            )
+
+    def test_load_krea2_transformer_rejects_incomplete_checkpoint(self, tmp_path):
+        """A truncated Krea checkpoint cannot leave meta parameters in the pipeline."""
+        from safetensors.torch import save_file
+
+        checkpoint = tmp_path / "krea2-incomplete.safetensors"
+        save_file(
+            {
+                "first.weight": torch.zeros((4, 2)),
+                "last.linear.weight": torch.zeros((4, 2)),
+                "blocks.0.attn.wq.weight": torch.zeros((4, 2)),
+            },
+            checkpoint,
+        )
+        with torch.device("meta"):
+            transformer = torch.nn.Module()
+            transformer.img_in = torch.nn.Linear(2, 4)
+            transformer.final_layer = torch.nn.Module()
+            transformer.final_layer.linear = torch.nn.Linear(2, 4, bias=False)
+            block = torch.nn.Module()
+            block.attn = torch.nn.Module()
+            block.attn.to_q = torch.nn.Linear(2, 4, bias=False)
+            transformer.transformer_blocks = torch.nn.ModuleList([block])
+        transformer._keep_in_fp32_modules = ["norm", "norm1", "norm2", "norm_q", "norm_k"]
+
+        pipeline = CivitaiCheckpointPipeline()
+        pipeline.policy = DevicePolicy(
+            device="cpu",
+            dtype=torch.bfloat16,
+            offload=OffloadMode.NEVER,
+        )
+
+        with (
+            patch("diffusers.Krea2Transformer2DModel") as mock_transformer_class,
+            pytest.raises(ValueError, match="Krea 2 checkpoint is missing tensors: img_in.bias"),
+        ):
+            mock_transformer_class.load_config.return_value = {"test": True}
+            mock_transformer_class.from_config.return_value = transformer
+            pipeline._load_krea2_transformer_from_single_file(
+                checkpoint,
+                "krea/Krea-2-Turbo",
+                "transformer",
+            )
+
+    def test_load_krea2_transformer_explains_gated_component_repo(self, tmp_path):
+        """A gated component failure tells operators how to authorize Hugging Face."""
+        pipeline = CivitaiCheckpointPipeline()
+
+        with (
+            patch("diffusers.Krea2Transformer2DModel") as mock_transformer_class,
+            pytest.raises(RuntimeError, match="accept its license.*HF_TOKEN"),
+        ):
+            mock_transformer_class.load_config.side_effect = OSError("not a valid model identifier")
+            pipeline._load_krea2_transformer_from_single_file(
+                tmp_path / "krea2.safetensors",
+                "krea/Krea-2-Turbo",
+                "transformer",
+            )
+
     def test_flux2_klein_4b_base_uses_4b_base_repo(self):
         """FLUX.2 Klein 4B base models default to the matching 4B base repo."""
         pipeline = CivitaiCheckpointPipeline()
         pipeline._base_model = "Flux.2 Klein 4B-base"
 
         assert pipeline._default_flux2_component_repo() == "black-forest-labs/FLUX.2-klein-base-4B"
+
+    @pytest.mark.parametrize(
+        ("source_key", "source_shape", "expected_key", "expected_shape"),
+        [
+            ("first.weight", (4, 2), "img_in.weight", (4, 2)),
+            (
+                "model.diffusion_model.first.weight",
+                (4, 2),
+                "img_in.weight",
+                (4, 2),
+            ),
+            ("tmlp.0.weight", (4, 2), "time_embed.linear_1.weight", (4, 2)),
+            ("tproj.1.bias", (24,), "time_mod_proj.bias", (24,)),
+            ("txtmlp.0.scale", (4,), "txt_in.norm.weight", (4,)),
+            (
+                "txtfusion.layerwise_blocks.0.attn.wq.weight",
+                (4, 4),
+                "text_fusion.layerwise_blocks.0.attn.to_q.weight",
+                (4, 4),
+            ),
+            (
+                "txtfusion.refiner_blocks.1.mlp.down.weight",
+                (4, 8),
+                "text_fusion.refiner_blocks.1.ff.down.weight",
+                (4, 8),
+            ),
+            (
+                "blocks.0.attn.qknorm.knorm.scale",
+                (2,),
+                "transformer_blocks.0.attn.norm_k.weight",
+                (2,),
+            ),
+            (
+                "blocks.0.attn.wo.weight",
+                (4, 4),
+                "transformer_blocks.0.attn.to_out.0.weight",
+                (4, 4),
+            ),
+            ("blocks.0.mod.lin", (24,), "transformer_blocks.0.scale_shift_table", (6, 4)),
+            ("last.modulation.lin", (8,), "final_layer.scale_shift_table", (2, 4)),
+            ("last.norm.scale", (4,), "final_layer.norm.weight", (4,)),
+        ],
+    )
+    def test_krea2_checkpoint_keys_convert_to_diffusers(
+        self,
+        source_key,
+        source_shape,
+        expected_key,
+        expected_shape,
+    ):
+        """Comfy Krea tensors map to the corresponding Diffusers parameters."""
+        tensor = torch.zeros(source_shape)
+
+        key, converted = CivitaiCheckpointPipeline._convert_krea2_checkpoint_tensor(
+            source_key, tensor
+        )
+
+        assert key == expected_key
+        assert converted.shape == expected_shape
+
+    def test_all_krea2_checkpoint_keys_exist_in_diffusers_model(self):
+        """Every published Comfy Krea tensor maps to a real Diffusers parameter."""
+        from accelerate import init_empty_weights
+        from diffusers import Krea2Transformer2DModel
+
+        source_keys = [
+            "first.bias",
+            "first.weight",
+            "last.linear.bias",
+            "last.linear.weight",
+            "last.modulation.lin",
+            "last.norm.scale",
+            "tmlp.0.bias",
+            "tmlp.0.weight",
+            "tmlp.2.bias",
+            "tmlp.2.weight",
+            "tproj.1.bias",
+            "tproj.1.weight",
+            "txtmlp.0.scale",
+            "txtmlp.1.bias",
+            "txtmlp.1.weight",
+            "txtmlp.3.bias",
+            "txtmlp.3.weight",
+            "txtfusion.projector.weight",
+        ]
+        block_suffixes = [
+            "attn.qknorm.knorm.scale",
+            "attn.qknorm.qnorm.scale",
+            "mod.lin",
+            "postnorm.scale",
+            "prenorm.scale",
+            "attn.gate.weight",
+            "attn.wk.weight",
+            "attn.wo.weight",
+            "attn.wq.weight",
+            "attn.wv.weight",
+            "mlp.down.weight",
+            "mlp.gate.weight",
+            "mlp.up.weight",
+        ]
+        text_block_suffixes = [suffix for suffix in block_suffixes if suffix != "mod.lin"]
+        source_keys.extend(
+            f"blocks.{index}.{suffix}" for index in range(28) for suffix in block_suffixes
+        )
+        source_keys.extend(
+            f"txtfusion.{group}.{index}.{suffix}"
+            for group in ("layerwise_blocks", "refiner_blocks")
+            for index in range(2)
+            for suffix in text_block_suffixes
+        )
+
+        with init_empty_weights():
+            model_keys = Krea2Transformer2DModel().state_dict().keys()
+
+        converted_keys = set()
+        for source_key in source_keys:
+            tensor_size = 6 if source_key.endswith(".mod.lin") else 2
+            key, _ = CivitaiCheckpointPipeline._convert_krea2_checkpoint_tensor(
+                source_key,
+                torch.empty(tensor_size),
+            )
+            assert key in model_keys
+            converted_keys.add(key)
+
+        assert len(source_keys) == len(converted_keys) == len(model_keys) == 430
 
     def test_transformer_checkpoint_strips_comfy_diffusion_model_prefix(self, tmp_path):
         """CivitAI/Comfy transformer checkpoints are normalized before conversion."""
@@ -1520,6 +1983,30 @@ class TestCivitaiCheckpointPipelineGenerate:
         assert call_kwargs["strength"] == 0.5
         assert "width" not in call_kwargs
         assert "height" not in call_kwargs
+
+    @pytest.mark.parametrize("argument", ["init_image", "mask_image"])
+    def test_generate_krea2_rejects_image_input(self, argument):
+        """CivitAI-backed Krea checkpoints remain text-to-image only."""
+        pipeline = CivitaiCheckpointPipeline()
+        pipeline._pipeline_config = PipelineConfig(pipeline_class="Krea2Pipeline")
+        pipeline.pipe = MagicMock()
+
+        with pytest.raises(ValueError, match="Krea 2 supports text-to-image only"):
+            pipeline.generate("test prompt", **{argument: b"dummy"})
+
+        pipeline.pipe.assert_not_called()
+
+    def test_generate_krea2_passes_negative_prompt(self):
+        """Fetched Krea Raw checkpoints keep user negative prompts for CFG."""
+        pipeline = CivitaiCheckpointPipeline()
+        pipeline._pipeline_config = get_pipeline_config_for_base_model("Krea 2")
+        mock_image = MagicMock(width=1024, height=1024)
+        pipeline.pipe = MagicMock(return_value=MagicMock(images=[mock_image]))
+
+        with patch.object(DevicePolicy, "clear_cache"):
+            pipeline.generate("test prompt", negative_prompt="blurry", guidance_scale=4.5)
+
+        assert pipeline.pipe.call_args.kwargs["negative_prompt"] == "blurry"
 
     def test_generate_flux2_klein_img2img_omits_strength(self):
         """Flux2 Klein accepts image input but not img2img strength."""


### PR DESCRIPTION
CivitAI reports Krea checkpoints as base model "Krea 2", but Diffusers does not provide a Krea single-file loader. This leaves checkpoints fetched by /fetch impossible to select with /model.

Stream compatible Comfy-format tensors into a meta-initialized Diffusers transformer and assemble it with matching hosted components. Reject unsupported quantized files, keep dtypes aligned, and let /fetch select a floating-point precision without cache collisions.