### PR TITLE
fix(civitai): harden checkpoint loading

### DIFF
--- a/src/oneiro/civitai.py
+++ b/src/oneiro/civitai.py
@@ -42,6 +42,12 @@ class CivitaiNotFoundError(CivitaiError):
     pass
 
 
+class CivitaiHeaderError(CivitaiError):
+    """Downloaded SafeTensor header is invalid or incomplete."""
+
+    pass
+
+
 class ModelType(StrEnum):
     """Civitai model types."""
 
@@ -165,12 +171,8 @@ class ModelVersion:
                 return f
         return self.files[0] if self.files else None
 
-    def select_checkpoint_file(
-        self,
-        precision: str = "auto",
-        preferred_precision: str = "bf16",
-    ) -> ModelFile:
-        """Select the best floating-point SafeTensor checkpoint for Diffusers."""
+    def checkpoint_files(self, preferred_precision: str = "bf16") -> list[ModelFile]:
+        """Return SafeTensor weight checkpoints ordered by precision and size."""
         supported_precisions = ("bf16", "fp16", "fp32")
         weight_file_types = {"model", "unet", "diffusion model"}
         candidates = [
@@ -178,20 +180,22 @@ class ModelVersion:
             for file in self.files
             if file.type.lower() in weight_file_types
             and (file.format or "").lower() == "safetensor"
-            and (file.fp or "").lower() in supported_precisions
         ]
         if not candidates:
-            raise CivitaiError("No Diffusers-compatible floating-point SafeTensor checkpoint found")
-
-        if precision != "auto":
-            candidates = [file for file in candidates if (file.fp or "").lower() == precision]
-            if not candidates:
-                raise CivitaiError(f"No {precision} SafeTensor checkpoint found")
+            raise CivitaiError("No Diffusers-compatible SafeTensor checkpoint found")
 
         precision_order = (preferred_precision,) + tuple(
             item for item in supported_precisions if item != preferred_precision
         )
-        return min(candidates, key=lambda file: precision_order.index((file.fp or "").lower()))
+        precision_rank = {item: rank for rank, item in enumerate(precision_order)}
+        return sorted(
+            candidates,
+            key=lambda file: (
+                precision_rank.get((file.fp or "").lower(), len(precision_order)),
+                -file.size_kb,
+                file.id,
+            ),
+        )
 
 
 @dataclass
@@ -744,7 +748,7 @@ class CivitaiClient:
             raise CivitaiError(f"SafeTensor header request failed: {error}") from error
 
         if len(data) != length:
-            raise CivitaiError("SafeTensor file ended before its header was complete")
+            raise CivitaiHeaderError("SafeTensor file ended before its header was complete")
         return bytes(data)
 
     async def get_safetensor_header(self, url: str) -> dict[str, Any]:
@@ -752,23 +756,23 @@ class CivitaiClient:
         prefix = await self._read_download_prefix(url, 8)
         header_size = int.from_bytes(prefix, "little")
         if not 0 < header_size <= self.MAX_SAFETENSOR_HEADER_BYTES:
-            raise CivitaiError("Invalid SafeTensor header size")
+            raise CivitaiHeaderError("Invalid SafeTensor header size")
 
         payload = await self._read_download_prefix(url, 8 + header_size)
         try:
             header = json.loads(payload[8:].decode("utf-8"))
-        except (UnicodeDecodeError, json.JSONDecodeError) as error:
-            raise CivitaiError("Invalid SafeTensor header") from error
+        except (UnicodeDecodeError, ValueError, RecursionError) as error:
+            raise CivitaiHeaderError("Invalid SafeTensor header") from error
         if not isinstance(header, dict):
-            raise CivitaiError("Invalid SafeTensor header")
+            raise CivitaiHeaderError("Invalid SafeTensor header")
         metadata = header.get("__metadata__", {})
         if not isinstance(metadata, dict):
-            raise CivitaiError("Invalid SafeTensor metadata")
+            raise CivitaiHeaderError("Invalid SafeTensor metadata")
         for key, descriptor in header.items():
             if key == "__metadata__":
                 continue
             if not isinstance(descriptor, dict):
-                raise CivitaiError("Invalid SafeTensor tensor descriptor")
+                raise CivitaiHeaderError("Invalid SafeTensor tensor descriptor")
             shape = descriptor.get("shape")
             offsets = descriptor.get("data_offsets")
             if (
@@ -780,7 +784,7 @@ class CivitaiClient:
                 or any(not isinstance(offset, int) or offset < 0 for offset in offsets)
                 or offsets[0] > offsets[1]
             ):
-                raise CivitaiError("Invalid SafeTensor tensor descriptor")
+                raise CivitaiHeaderError("Invalid SafeTensor tensor descriptor")
         return header
 
     async def download_model_version(

--- a/src/oneiro/discord/commands.py
+++ b/src/oneiro/discord/commands.py
@@ -1,5 +1,6 @@
 """Slash command definitions for Oneiro Discord bot."""
 
+import inspect
 import re
 from contextlib import suppress
 from pathlib import Path
@@ -7,10 +8,21 @@ from typing import TYPE_CHECKING, Any
 
 import discord
 from discord import option
+from safetensors import SafetensorError
 
-from oneiro.civitai import CivitaiClient, CivitaiError, ModelFile, parse_civitai_url
+from oneiro.civitai import (
+    CivitaiClient,
+    CivitaiError,
+    CivitaiHeaderError,
+    ModelFile,
+    parse_civitai_url,
+)
 from oneiro.device import DevicePolicy
-from oneiro.discord.handlers import DreamContext, create_dream_callbacks
+from oneiro.discord.handlers import (
+    DreamContext,
+    create_dream_callbacks,
+    format_exception_response,
+)
 from oneiro.pipelines import SCHEDULER_CHOICES
 from oneiro.pipelines.civitai_checkpoint import (
     DEFAULT_KREA2_COMPONENT_REPO,
@@ -102,6 +114,27 @@ def _discard_invalid_civitai_download(
             client.cache.remove(model_file.sha256)
     with suppress(OSError):
         path.unlink(missing_ok=True)
+
+
+def get_generation_defaults(pipeline: Any) -> tuple[int, float]:
+    """Return configured or declared generation defaults for a loaded pipeline."""
+    if pipeline is None:
+        return 9, 0.0
+    pipeline_config = getattr(pipeline, "pipeline_config", None)
+    steps = getattr(pipeline_config, "default_steps", None)
+    guidance = getattr(pipeline_config, "default_guidance_scale", None)
+    try:
+        parameters = inspect.signature(pipeline.generate).parameters
+    except (TypeError, ValueError):
+        parameters = {}
+    if not isinstance(steps, int):
+        steps = getattr(parameters.get("steps"), "default", 9)
+    if not isinstance(guidance, int | float):
+        guidance = getattr(parameters.get("guidance_scale"), "default", 0.0)
+    return (
+        steps if isinstance(steps, int) else 9,
+        float(guidance) if isinstance(guidance, int | float) else 0.0,
+    )
 
 
 def validate_image_attachment(attachment: discord.Attachment, label: str) -> str | None:
@@ -324,7 +357,9 @@ def register_commands(bot: "OneiroBot") -> None:
             try:
                 init_image_bytes = await image.read()
             except Exception as e:
-                await ctx.followup.send(f"❌ Failed to read image: {e}", ephemeral=True)
+                await ctx.followup.send(
+                    **format_exception_response("❌ Failed to read image", e), ephemeral=True
+                )
                 return
 
         mask_image_bytes: bytes | None = None
@@ -338,12 +373,18 @@ def register_commands(bot: "OneiroBot") -> None:
             try:
                 mask_image_bytes = await mask.read()
             except Exception as e:
-                await ctx.followup.send(f"❌ Failed to read mask image: {e}", ephemeral=True)
+                await ctx.followup.send(
+                    **format_exception_response("❌ Failed to read mask image", e),
+                    ephemeral=True,
+                )
                 return
 
         # Get model config defaults
-        model_steps = model_config.get("steps", 9)
-        model_guidance = model_config.get("guidance_scale", 0.0)
+        pipeline_steps, pipeline_guidance = get_generation_defaults(
+            ctx.bot.pipeline_manager.pipeline
+        )
+        model_steps = model_config.get("steps", pipeline_steps)
+        model_guidance = model_config.get("guidance_scale", pipeline_guidance)
 
         # Handle Qwen's true_cfg_scale
         if model_config.get("true_cfg_scale"):
@@ -576,7 +617,11 @@ def register_commands(bot: "OneiroBot") -> None:
 
         try:
             loading_msg = await ctx.followup.send(f"⏳ Loading model `{model}`...")
-            await ctx.bot.pipeline_manager.load_model(model)
+            try:
+                await ctx.bot.pipeline_manager.load_model(model)
+            except (CivitaiError, ValueError) as e:
+                await ctx.followup.send(f"❌ Failed to load model: {e}", ephemeral=True)
+                return
 
             if scheduler and ctx.bot.pipeline_manager.pipeline is not None:
                 if isinstance(ctx.bot.pipeline_manager.pipeline, CivitaiCheckpointPipeline):
@@ -604,7 +649,9 @@ def register_commands(bot: "OneiroBot") -> None:
                 msg += f" with {', '.join(overrides)}"
             await loading_msg.edit(content=msg)
         except Exception as e:
-            await ctx.followup.send(f"❌ Failed to load model: {e}", ephemeral=True)
+            await ctx.followup.send(
+                **format_exception_response("❌ Failed to load model", e), ephemeral=True
+            )
 
     @bot.slash_command(name="config", description="Show current configuration")
     async def config_command(ctx: discord.ApplicationContext) -> None:
@@ -759,54 +806,92 @@ def register_commands(bot: "OneiroBot") -> None:
             selected_file = None
             selected_precision = None
             component_repo = None
-            cached_checkpoint = None
+            downloaded_path = None
             if model_type == "CHECKPOINT" and is_krea2_base_model(version.base_model):
                 policy_precision = {
                     "bfloat16": "bf16",
                     "float16": "fp16",
                     "float32": "fp32",
                 }[str(DevicePolicy.auto_detect().dtype).removeprefix("torch.")]
-                selected_file = version.select_checkpoint_file(
-                    precision,
-                    preferred_precision=policy_precision,
+                candidates = version.checkpoint_files(
+                    preferred_precision=(precision if precision != "auto" else policy_precision),
                 )
                 component_repo = krea2_component_repo(
                     model.name,
                     version.name,
                     krea2_variant,
                 )
-                if selected_file.sha256:
-                    cached_checkpoint = ctx.bot.civitai_client.cache.get(selected_file.sha256)
-                try:
-                    if cached_checkpoint:
-                        selected_precision = get_krea2_checkpoint_precision(cached_checkpoint)
-                    else:
-                        header = await ctx.bot.civitai_client.get_safetensor_header(
-                            selected_file.download_url
+                last_error = None
+                for candidate in candidates:
+                    cached = (
+                        ctx.bot.civitai_client.cache.get(candidate.sha256)
+                        if candidate.sha256
+                        else None
+                    )
+                    if cached:
+                        try:
+                            selected_precision = get_krea2_checkpoint_precision(cached)
+                        except (SafetensorError, ValueError):
+                            _discard_invalid_civitai_download(
+                                ctx.bot.civitai_client,
+                                candidate,
+                                cached,
+                            )
+                            cached = None
+                    if not cached:
+                        try:
+                            header = await ctx.bot.civitai_client.get_safetensor_header(
+                                candidate.download_url
+                            )
+                        except CivitaiHeaderError as error:
+                            last_error = error
+                            continue
+                        except CivitaiError:
+                            raise
+                        try:
+                            selected_precision = get_krea2_checkpoint_precision_from_header(header)
+                        except ValueError as error:
+                            last_error = error
+                            continue
+                    if precision != "auto" and selected_precision != precision:
+                        last_error = CivitaiError(
+                            f"Checkpoint contains {selected_precision}, not requested {precision}"
                         )
-                        selected_precision = get_krea2_checkpoint_precision_from_header(header)
-                except Exception as error:
-                    if cached_checkpoint:
+                        continue
+                    if cached:
+                        selected_file = candidate
+                        downloaded_path = cached
+                        break
+
+                    candidate_path = await ctx.bot.civitai_client.download_model_version(
+                        version,
+                        model_file=candidate,
+                    )
+                    try:
+                        candidate_precision = get_krea2_checkpoint_precision(candidate_path)
+                    except (SafetensorError, ValueError) as error:
                         _discard_invalid_civitai_download(
                             ctx.bot.civitai_client,
-                            selected_file,
-                            cached_checkpoint,
+                            candidate,
+                            candidate_path,
                         )
-                    raise CivitaiError(str(error)) from error
-            downloaded_path = await ctx.bot.civitai_client.download_model_version(
-                version,
-                model_file=selected_file,
-            )
-            if selected_file:
-                try:
-                    selected_precision = get_krea2_checkpoint_precision(downloaded_path)
-                except Exception as error:
-                    _discard_invalid_civitai_download(
-                        ctx.bot.civitai_client,
-                        selected_file,
-                        downloaded_path,
+                        last_error = error
+                        continue
+                    if precision != "auto" and candidate_precision != precision:
+                        last_error = CivitaiError(
+                            f"Checkpoint contains {candidate_precision}, not requested {precision}"
+                        )
+                        continue
+                    selected_file = candidate
+                    selected_precision = candidate_precision
+                    downloaded_path = candidate_path
+                    break
+                if selected_file is None:
+                    raise CivitaiError(
+                        str(last_error) if last_error else "No valid Krea 2 checkpoint found"
                     )
-                    raise CivitaiError(str(error)) from error
+            else:
+                downloaded_path = await ctx.bot.civitai_client.download_model_version(version)
 
             # Get current pipeline type for compatibility info
             pipeline_type = None
@@ -957,6 +1042,16 @@ def register_commands(bot: "OneiroBot") -> None:
                     value=f"`{selected_precision}`",
                     inline=True,
                 )
+                if component_repo:
+                    recipe_steps, recipe_guidance = get_krea2_generation_defaults(component_repo)
+                    embed.add_field(
+                        name="Krea 2 Recipe",
+                        value=(
+                            f"`{component_repo}`\n"
+                            f"{recipe_steps} steps | guidance {recipe_guidance:g}"
+                        ),
+                        inline=False,
+                    )
             elif precision != "auto":
                 embed.add_field(
                     name="Precision",
@@ -982,4 +1077,6 @@ def register_commands(bot: "OneiroBot") -> None:
         except CivitaiError as e:
             await ctx.followup.send(f"❌ Civitai error: {e}", ephemeral=True)
         except Exception as e:
-            await ctx.followup.send(f"❌ Failed to fetch: {e}", ephemeral=True)
+            await ctx.followup.send(
+                **format_exception_response("❌ Failed to fetch", e), ephemeral=True
+            )

--- a/src/oneiro/discord/handlers.py
+++ b/src/oneiro/discord/handlers.py
@@ -1,6 +1,9 @@
 """Event handlers and callback factories for Discord bot."""
 
+import io
+import re
 import time
+import traceback
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
@@ -12,6 +15,26 @@ from oneiro.pipelines import GenerationResult, LoraConfig
 if TYPE_CHECKING:
     from oneiro.app import OneiroBot
     from oneiro.pipelines import PipelineManager
+
+
+_TOKEN_PATTERN = re.compile(r"([?&]token=)[^&\s'\"`]+", re.IGNORECASE)
+
+
+def _sanitize_error_text(text: str) -> str:
+    """Redact CivitAI API tokens from exception text."""
+    return _TOKEN_PATTERN.sub(r"\1<redacted>", text)
+
+
+def format_exception_response(prefix: str, error: BaseException) -> dict[str, Any]:
+    """Build Discord send arguments for a sanitized traceback response."""
+    trace = _sanitize_error_text("".join(traceback.format_exception(error)))
+    message = f"{prefix}\n```py\n{trace}\n```"
+    response: dict[str, Any] = {"content": message}
+    if len(message) > 2000:
+        preview = 2000 - len(prefix) - len("\n```py\n...\n```")
+        response["content"] = f"{prefix}\n```py\n{trace[:preview]}...\n```"
+        response["file"] = discord.File(io.BytesIO(trace.encode()), filename="traceback.txt")
+    return response
 
 
 @dataclass
@@ -73,13 +96,25 @@ def create_dream_callbacks(
 
     async def on_complete(result: GenerationResult | Exception) -> None:
         if isinstance(result, Exception):
+            prefix = "❌ Generation failed"
+            separator = ": "
+            ellipsis = "..."
+            max_reason_length = 2000 - len(prefix) - len(separator) - len(ellipsis)
+            reason = _sanitize_error_text(str(result))
+            if len(reason) > max_reason_length:
+                reason = f"{reason[:max_reason_length]}{ellipsis}"
+            public_message = f"{prefix}{separator}{reason}"
             if context.status_message:
                 try:
-                    await context.status_message.edit(content=f"❌ Generation failed: {result}")
+                    await context.status_message.edit(content=public_message)
                 except discord.errors.NotFound:
-                    await context.ctx.followup.send(f"❌ Generation failed: {result}")
+                    await context.ctx.followup.send(public_message)
             else:
-                await context.ctx.followup.send(f"❌ Generation failed: {result}")
+                await context.ctx.followup.send(public_message)
+
+            await context.ctx.followup.send(
+                **format_exception_response(prefix, result), ephemeral=True
+            )
             return
 
         elapsed = time.time() - context.start_time

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -1,16 +1,29 @@
 """Tests for bot helper functions."""
 
+from collections.abc import Callable
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import discord
+import httpx
 import pytest
+import respx
+from discord.webhook.async_ import handle_message_parameters
 
-from oneiro.civitai import ModelVersion
+from oneiro.civitai import CivitaiClient, CivitaiError, ModelVersion
 from oneiro.discord.commands import (
+    get_generation_defaults,
     is_krea2_base_model,
     krea2_component_repo,
     register_commands,
     slugify,
 )
+from oneiro.discord.handlers import (
+    DreamContext,
+    create_dream_callbacks,
+    format_exception_response,
+)
+from oneiro.pipelines.civitai_checkpoint import get_krea2_checkpoint_precision
 from oneiro.queue import QueueStatus
 from oneiro.services.generation import (
     MAX_LORA_WEIGHT,
@@ -18,6 +31,293 @@ from oneiro.services.generation import (
     parse_lora_param,
     validate_lora_weight,
 )
+
+
+def _register_test_commands() -> dict[str, Any]:
+    commands = {}
+    bot = MagicMock()
+
+    def slash_command(**kwargs: Any) -> Callable[[Any], Any]:
+        def register(command: Any) -> Any:
+            commands[kwargs["name"]] = command
+            return command
+
+        return register
+
+    bot.slash_command.side_effect = slash_command
+    register_commands(bot)
+    return commands
+
+
+def test_short_exception_response_omits_file_and_is_valid_for_pycord():
+    """Short traceback responses omit py-cord's invalid file=None value."""
+    response = format_exception_response("❌ Failed", RuntimeError("short"))
+
+    assert "file" not in response
+    handle_message_parameters(**response)
+
+
+def test_exception_response_redacts_tokens_from_preview_and_attachment():
+    """Tokenized URLs are redacted from every traceback representation."""
+    request = httpx.Request("GET", "https://civitai.com/download?token=SUPER_SECRET")
+    http_response = httpx.Response(401, request=request)
+
+    try:
+        http_response.raise_for_status()
+    except httpx.HTTPStatusError as cause:
+        try:
+            raise RuntimeError("x" * 3000) from cause
+        except RuntimeError as error:
+            response = format_exception_response("❌ Failed", error)
+
+    assert "SUPER_SECRET" not in response["content"]
+    assert "SUPER_SECRET" not in response["file"].fp.getvalue().decode()
+
+
+async def test_generation_traceback_is_ephemeral_and_attaches_full_trace_when_truncated():
+    """Queued generation failures keep details private and preserve the full traceback."""
+    ctx = MagicMock()
+    ctx.followup.send = AsyncMock()
+    status_message = MagicMock()
+    status_message.edit = AsyncMock()
+    context = DreamContext(
+        ctx=ctx,
+        prompt="test prompt",
+        negative_prompt=None,
+        current_model="test-model",
+        scheduler=None,
+        lora_configs=[],
+        auto_detected_loras=[],
+        is_img2img=False,
+        is_inpaint=False,
+        strength=0.0,
+        pipeline_manager=MagicMock(),
+        status_message=status_message,
+    )
+
+    _, _, on_complete = create_dream_callbacks(context)
+    error_message = "x" * 3000
+    try:
+        raise RuntimeError(error_message)
+    except RuntimeError as cause:
+        try:
+            raise CivitaiError("Download failed: HTTP 401") from cause
+        except CivitaiError as error:
+            await on_complete(error)
+
+    context.status_message.edit.assert_awaited_once_with(
+        content="❌ Generation failed: Download failed: HTTP 401"
+    )
+    call = context.ctx.followup.send.await_args
+    assert call.kwargs["content"].startswith("❌ Generation failed")
+    assert "Traceback (most recent call last)" in call.kwargs["content"]
+    assert len(call.kwargs["content"]) <= 2000
+    assert call.kwargs["ephemeral"] is True
+    assert call.kwargs["file"].filename == "traceback.txt"
+    assert error_message in call.kwargs["file"].fp.getvalue().decode()
+
+
+async def test_generation_public_summary_is_bounded_for_long_top_level_error():
+    """Long top-level errors keep the public summary within Discord's limit."""
+    ctx = MagicMock()
+    ctx.followup.send = AsyncMock()
+    status_message = MagicMock()
+    status_message.edit = AsyncMock()
+    context = DreamContext(
+        ctx=ctx,
+        prompt="test prompt",
+        negative_prompt=None,
+        current_model="test-model",
+        scheduler=None,
+        lora_configs=[],
+        auto_detected_loras=[],
+        is_img2img=False,
+        is_inpaint=False,
+        strength=0.0,
+        pipeline_manager=MagicMock(),
+        status_message=status_message,
+    )
+
+    _, _, on_complete = create_dream_callbacks(context)
+    await on_complete(RuntimeError("useful context " + "x" * 3000))
+
+    public_message = status_message.edit.await_args.kwargs["content"]
+    assert len(public_message) <= 2000
+    assert public_message.startswith("❌ Generation failed: useful context ")
+    assert public_message.endswith("...")
+    private_call = context.ctx.followup.send.await_args
+    assert private_call.kwargs["ephemeral"] is True
+    assert "RuntimeError: useful context" in private_call.kwargs["content"]
+    assert private_call.kwargs["file"].filename == "traceback.txt"
+
+
+async def test_generation_traceback_not_found_sends_distinct_public_and_private_messages():
+    """A missing status message gets a sanitized summary and separate private traceback."""
+    ctx = MagicMock()
+    ctx.followup.send = AsyncMock()
+    status_message = MagicMock()
+    status_message.edit = AsyncMock(
+        side_effect=discord.errors.NotFound(
+            MagicMock(status=404, reason="Not Found"),
+            {"message": "Unknown Message", "code": 10008},
+        )
+    )
+    context = DreamContext(
+        ctx=ctx,
+        prompt="test prompt",
+        negative_prompt=None,
+        current_model="test-model",
+        scheduler=None,
+        lora_configs=[],
+        auto_detected_loras=[],
+        is_img2img=False,
+        is_inpaint=False,
+        strength=0.0,
+        pipeline_manager=MagicMock(),
+        status_message=status_message,
+    )
+
+    _, _, on_complete = create_dream_callbacks(context)
+    await on_complete(
+        RuntimeError("Download failed: https://civitai.com/download?token=SUPER_SECRET")
+    )
+
+    public_call, private_call = context.ctx.followup.send.await_args_list
+    public_message = public_call.args[0]
+    assert "SUPER_SECRET" not in status_message.edit.await_args.kwargs["content"]
+    assert "SUPER_SECRET" not in public_message
+    assert "token=<redacted>" in public_message
+    assert private_call.kwargs["content"] != public_call.args[0]
+    assert private_call.kwargs["ephemeral"] is True
+
+
+async def test_model_error_includes_traceback_and_attaches_full_trace_when_truncated():
+    """Unexpected model failures retain the complete traceback without exceeding Discord limits."""
+    commands = _register_test_commands()
+    error = RuntimeError("x" * 3000)
+    ctx = MagicMock()
+    ctx.defer = AsyncMock()
+    ctx.followup.send = AsyncMock(return_value=MagicMock())
+    ctx.bot.config.get.return_value = {"type": "test"}
+    ctx.bot.pipeline_manager.current_model = "working"
+    ctx.bot.pipeline_manager.load_model = AsyncMock(side_effect=error)
+
+    await commands["model"](ctx, "broken")
+
+    call = ctx.followup.send.await_args_list[-1]
+    assert call.kwargs["content"].startswith("❌ Failed to load model")
+    assert "Traceback (most recent call last)" in call.kwargs["content"]
+    assert len(call.kwargs["content"]) <= 2000
+    assert call.kwargs["ephemeral"] is True
+    assert call.kwargs["file"].filename == "traceback.txt"
+    assert str(error) in call.kwargs["file"].fp.getvalue().decode()
+
+
+@pytest.mark.parametrize(
+    "error",
+    [CivitaiError("checkpoint download failed"), ValueError("invalid model configuration")],
+)
+async def test_model_expected_error_is_concise_and_ephemeral(error):
+    """Expected model failures omit traceback details and attachments."""
+    commands = _register_test_commands()
+    ctx = MagicMock()
+    ctx.defer = AsyncMock()
+    ctx.followup.send = AsyncMock(return_value=MagicMock())
+    ctx.bot.config.get.return_value = {"type": "test"}
+    ctx.bot.pipeline_manager.current_model = "working"
+    ctx.bot.pipeline_manager.load_model = AsyncMock(side_effect=error)
+
+    await commands["model"](ctx, "broken")
+
+    call = ctx.followup.send.await_args_list[-1]
+    assert call.args == (f"❌ Failed to load model: {error}",)
+    assert call.kwargs == {"ephemeral": True}
+
+
+async def test_model_post_load_value_error_includes_traceback():
+    """Unexpected state persistence failures retain their traceback."""
+    commands = _register_test_commands()
+    error = ValueError("state persistence failed")
+    ctx = MagicMock()
+    ctx.defer = AsyncMock()
+    ctx.followup.send = AsyncMock(return_value=MagicMock())
+    ctx.bot.config.get.return_value = {"type": "test"}
+    ctx.bot.config.state_path = "state.toml"
+    ctx.bot.config.set.side_effect = error
+    ctx.bot.pipeline_manager.current_model = "working"
+    ctx.bot.pipeline_manager.load_model = AsyncMock()
+
+    await commands["model"](ctx, "broken")
+
+    call = ctx.followup.send.await_args_list[-1]
+    assert call.kwargs["content"].startswith("❌ Failed to load model")
+    assert "Traceback (most recent call last)" in call.kwargs["content"]
+    assert "ValueError: state persistence failed" in call.kwargs["content"]
+    assert call.kwargs.keys() == {"content", "ephemeral"}
+
+
+async def test_fetch_error_includes_traceback():
+    """Unexpected fetch failures include their traceback in the response."""
+    commands = _register_test_commands()
+    error = RuntimeError("fetch exploded")
+    ctx = MagicMock()
+    ctx.defer = AsyncMock()
+    ctx.followup.send = AsyncMock(return_value=MagicMock())
+    ctx.bot.config.state_path = "state.toml"
+    ctx.bot.civitai_client.get_model = AsyncMock(side_effect=error)
+
+    await commands["fetch"](ctx, "https://civitai.com/models/1")
+
+    call = ctx.followup.send.await_args_list[-1]
+    assert call.kwargs["content"].startswith("❌ Failed to fetch")
+    assert "Traceback (most recent call last)" in call.kwargs["content"]
+    assert "RuntimeError: fetch exploded" in call.kwargs["content"]
+    assert call.kwargs.keys() == {"content", "ephemeral"}
+
+
+async def test_image_read_error_includes_traceback():
+    """Unexpected image read failures include their traceback in the response."""
+    commands = _register_test_commands()
+    error = RuntimeError("image exploded")
+    image = MagicMock(filename="image.png", content_type="image/png", size=1)
+    image.read = AsyncMock(side_effect=error)
+    ctx = MagicMock()
+    ctx.defer = AsyncMock()
+    ctx.followup.send = AsyncMock()
+    ctx.bot.content_filter = None
+    ctx.bot.config = None
+
+    await commands["dream"](ctx, "prompt", image=image)
+
+    call = ctx.followup.send.await_args_list[-1]
+    assert call.kwargs["content"].startswith("❌ Failed to read image")
+    assert "Traceback (most recent call last)" in call.kwargs["content"]
+    assert "RuntimeError: image exploded" in call.kwargs["content"]
+    assert call.kwargs.keys() == {"content", "ephemeral"}
+
+
+async def test_mask_read_error_includes_traceback():
+    """Unexpected mask read failures include their traceback in the response."""
+    commands = _register_test_commands()
+    error = RuntimeError("mask exploded")
+    image = MagicMock(filename="image.png", content_type="image/png", size=1)
+    image.read = AsyncMock(return_value=b"image")
+    mask = MagicMock(filename="mask.png", content_type="image/png", size=1)
+    mask.read = AsyncMock(side_effect=error)
+    ctx = MagicMock()
+    ctx.defer = AsyncMock()
+    ctx.followup.send = AsyncMock()
+    ctx.bot.content_filter = None
+    ctx.bot.config = None
+    ctx.bot.pipeline_manager.pipeline.supports_inpaint = True
+
+    await commands["dream"](ctx, "prompt", image=image, mask=mask)
+
+    call = ctx.followup.send.await_args_list[-1]
+    assert call.kwargs["content"].startswith("❌ Failed to read mask image")
+    assert "Traceback (most recent call last)" in call.kwargs["content"]
+    assert "RuntimeError: mask exploded" in call.kwargs["content"]
+    assert call.kwargs.keys() == {"content", "ephemeral"}
 
 
 class TestSlugify:
@@ -79,6 +379,21 @@ def test_krea2_component_repo_follows_civitai_names(model_name, version_name, ex
     assert krea2_component_repo(model_name, version_name) == expected
 
 
+def test_get_generation_defaults_uses_wrapper_signature():
+    """Native wrappers retain their declared generation defaults."""
+
+    class Pipeline:
+        def generate(self, prompt, steps=28, guidance_scale=3.5):
+            pass
+
+    assert get_generation_defaults(Pipeline()) == (28, 3.5)
+
+
+def test_get_generation_defaults_handles_unloaded_pipeline():
+    """A failed model load can still queue a request for automatic reload."""
+    assert get_generation_defaults(None) == (9, 0.0)
+
+
 @pytest.mark.parametrize(
     ("checkpoint_kind", "writes_config"),
     [
@@ -87,9 +402,15 @@ def test_krea2_component_repo_follows_civitai_names(model_name, version_name, ex
         ("lora", False),
         ("malformed", False),
         ("cached", True),
-        ("cached_malformed", False),
+        ("cached_malformed", True),
+        ("cached_io_error", False),
+        ("fallback", True),
+        ("precision_mismatch", True),
+        ("local_fallback", True),
+        ("transport", False),
     ],
 )
+@respx.mock
 async def test_fetch_krea2_validates_header_before_writing_config(
     checkpoint_kind, writes_config, tmp_path
 ):
@@ -107,23 +428,40 @@ async def test_fetch_krea2_validates_header_before_writing_config(
     bot.slash_command.side_effect = slash_command
     register_commands(bot)
 
+    files = [
+        {
+            "id": 3,
+            "name": "krea.safetensors",
+            "sizeKB": 200,
+            "type": "Model",
+            "downloadUrl": "https://civitai.com/download/3",
+            "metadata": {"format": "SafeTensor", "fp": "bf16"},
+            "hashes": {"SHA256": "ABC123"},
+            "primary": True,
+        }
+    ]
+    if checkpoint_kind in {"fallback", "precision_mismatch", "local_fallback", "transport"}:
+        files.append(
+            {
+                "id": 4,
+                "name": "krea.safetensors",
+                "sizeKB": 100,
+                "type": "Model",
+                "downloadUrl": "https://civitai.com/download/4",
+                "metadata": {
+                    "format": "SafeTensor",
+                    "fp": "fp16" if checkpoint_kind == "precision_mismatch" else "bf16",
+                },
+                "hashes": {"SHA256": "DEF456"},
+            }
+        )
     version = ModelVersion.from_dict(
         {
             "id": 2,
             "modelId": 1,
             "name": "v1 Turbo",
             "baseModel": "Krea 2",
-            "files": [
-                {
-                    "id": 3,
-                    "name": "krea.safetensors",
-                    "type": "Model",
-                    "downloadUrl": "https://civitai.com/download/3",
-                    "metadata": {"format": "SafeTensor", "fp": "bf16"},
-                    "hashes": {"SHA256": "ABC123"},
-                    "primary": True,
-                }
-            ],
+            "files": files,
         }
     )
     model = MagicMock()
@@ -167,45 +505,151 @@ async def test_fetch_krea2_validates_header_before_writing_config(
     else:
         save_file(tensors, downloaded_path)
 
-    header_kind = "krea" if malformed or checkpoint_kind == "cached" else checkpoint_kind
+    header_kind = (
+        "krea"
+        if malformed or checkpoint_kind in {"cached", "precision_mismatch"}
+        else checkpoint_kind
+    )
     header_dtype = "I8" if header_kind == "quantized" else "BF16"
     header_keys = (
         ["lora_unet_blocks_0_attn_wq.alpha"]
         if header_kind == "lora"
         else ["first.weight", "last.linear.weight", "blocks.0.attn.wq.weight"]
     )
-    ctx.bot.civitai_client.get_safetensor_header = AsyncMock(
-        return_value={
-            key: {"dtype": header_dtype, "shape": [1], "data_offsets": [0, 2]}
-            for key in header_keys
-        }
-    )
+    header = {
+        key: {"dtype": header_dtype, "shape": [1], "data_offsets": [0, 2]} for key in header_keys
+    }
+    header_client = None
+    header_route = None
+    if checkpoint_kind == "krea":
+        contents = downloaded_path.read_bytes()
+        header_size = int.from_bytes(contents[:8], "little")
+        header_route = respx.get("https://civitai.com/download/3")
+        header_route.side_effect = [
+            httpx.Response(
+                206,
+                content=contents[:8],
+                headers={"Content-Range": f"bytes 0-7/{len(contents)}"},
+            ),
+            httpx.Response(
+                206,
+                content=contents[: 8 + header_size],
+                headers={"Content-Range": f"bytes 0-{7 + header_size}/{len(contents)}"},
+            ),
+        ]
+        header_client = CivitaiClient(cache_dir=tmp_path)
+        ctx.bot.civitai_client.get_safetensor_header = header_client.get_safetensor_header
+    elif checkpoint_kind in {"fallback", "precision_mismatch"}:
+        first_dtype = "F16" if checkpoint_kind == "precision_mismatch" else "BF16"
+        ctx.bot.civitai_client.get_safetensor_header = AsyncMock(
+            side_effect=[
+                (
+                    {
+                        key: {
+                            "dtype": first_dtype,
+                            "shape": [1],
+                            "data_offsets": [0, 2],
+                        }
+                        for key in header_keys
+                    }
+                    if checkpoint_kind == "precision_mismatch"
+                    else {
+                        "lora.alpha": {
+                            "dtype": "BF16",
+                            "shape": [1],
+                            "data_offsets": [0, 2],
+                        }
+                    }
+                ),
+                header,
+            ]
+        )
+    elif checkpoint_kind == "local_fallback":
+        ctx.bot.civitai_client.get_safetensor_header = AsyncMock(return_value=header)
+    elif checkpoint_kind == "transport":
+        ctx.bot.civitai_client.get_safetensor_header = AsyncMock(
+            side_effect=CivitaiError("header request failed")
+        )
+    else:
+        ctx.bot.civitai_client.get_safetensor_header = AsyncMock(return_value=header)
     ctx.bot.civitai_client.cache.get.return_value = (
         downloaded_path if checkpoint_kind.startswith("cached") else None
     )
-    ctx.bot.civitai_client.download_model_version = AsyncMock(return_value=downloaded_path)
 
-    with patch("oneiro.discord.commands.DevicePolicy.auto_detect") as auto_detect:
+    async def download_model_version(*args, **kwargs):
+        if checkpoint_kind == "cached_malformed":
+            save_file(
+                {
+                    "first.weight": torch.ones(1, dtype=torch.bfloat16),
+                    "last.linear.weight": torch.ones(1, dtype=torch.bfloat16),
+                    "blocks.0.attn.wq.weight": torch.ones(1, dtype=torch.bfloat16),
+                },
+                downloaded_path,
+            )
+        elif checkpoint_kind == "local_fallback":
+            if kwargs["model_file"].id == 3:
+                downloaded_path.write_bytes(b"not a safetensor")
+            else:
+                save_file(
+                    {
+                        "first.weight": torch.ones(1, dtype=torch.bfloat16),
+                        "last.linear.weight": torch.ones(1, dtype=torch.bfloat16),
+                        "blocks.0.attn.wq.weight": torch.ones(1, dtype=torch.bfloat16),
+                    },
+                    downloaded_path,
+                )
+        return downloaded_path
+
+    ctx.bot.civitai_client.download_model_version = AsyncMock(side_effect=download_model_version)
+
+    with (
+        patch("oneiro.discord.commands.DevicePolicy.auto_detect") as auto_detect,
+        patch(
+            "oneiro.discord.commands.get_krea2_checkpoint_precision",
+            wraps=get_krea2_checkpoint_precision,
+        ) as inspect_local_precision,
+    ):
         auto_detect.return_value.dtype = "bfloat16"
+        if checkpoint_kind == "cached_io_error":
+            inspect_local_precision.side_effect = OSError("cached checkpoint read failed")
         await commands["fetch"](
             ctx,
             "https://civitai.com/models/1",
+            precision="bf16" if checkpoint_kind == "precision_mismatch" else "auto",
             krea2_variant="raw",
         )
+    if header_client:
+        await header_client.close()
 
     assert ctx.bot.config.set.called is writes_config
     if writes_config:
-        ctx.bot.civitai_client.download_model_version.assert_awaited_once()
         if checkpoint_kind == "cached":
+            inspect_local_precision.assert_called_once_with(downloaded_path)
+            ctx.bot.civitai_client.download_model_version.assert_not_awaited()
             ctx.bot.civitai_client.get_safetensor_header.assert_not_awaited()
         else:
-            ctx.bot.civitai_client.get_safetensor_header.assert_awaited_once()
+            expected_downloads = 2 if checkpoint_kind == "local_fallback" else 1
+            assert ctx.bot.civitai_client.download_model_version.await_count == expected_downloads
+        if checkpoint_kind == "krea":
+            assert header_route is not None and header_route.call_count == 2
+        elif checkpoint_kind != "cached":
+            expected_calls = (
+                2 if checkpoint_kind in {"fallback", "precision_mismatch", "local_fallback"} else 1
+            )
+            assert ctx.bot.civitai_client.get_safetensor_header.await_count == expected_calls
+        if checkpoint_kind in {"fallback", "precision_mismatch", "local_fallback"}:
+            selected = ctx.bot.civitai_client.download_model_version.call_args.kwargs["model_file"]
+            assert selected.id == 4
         checkpoint_config = ctx.bot.config.set.call_args.kwargs["value"]
         assert checkpoint_config["krea2_component_repo"] == "krea/Krea-2-Raw"
         assert checkpoint_config["steps"] == 28
         assert checkpoint_config["guidance_scale"] == 4.5
         embed = status.edit.call_args.kwargs["embed"]
         assert next(field.value for field in embed.fields if field.name == "Precision") == "`bf16`"
+        recipe = next(field.value for field in embed.fields if field.name == "Krea 2 Recipe")
+        assert "krea/Krea-2-Raw" in recipe
+        assert "28 steps" in recipe
+        assert "guidance 4.5" in recipe
 
         ctx.bot.pipeline_manager = MagicMock(current_model="fetched-krea")
         ctx.bot.content_filter = None
@@ -232,18 +676,47 @@ async def test_fetch_krea2_validates_header_before_writing_config(
         request = ctx.bot.generation_queue.add.call_args.kwargs["request"]
         assert request["steps"] == 28
         assert request["guidance_scale"] == 4.5
-    elif checkpoint_kind in {"quantized", "lora"}:
+
+        operator_config = {
+            key: value
+            for key, value in checkpoint_config.items()
+            if key not in {"steps", "guidance_scale"}
+        }
+        ctx.bot.pipeline_manager.pipeline.pipeline_config.default_steps = 28
+        ctx.bot.pipeline_manager.pipeline.pipeline_config.default_guidance_scale = 4.5
+        ctx.bot.config.get.side_effect = lambda *keys, default=None: (
+            operator_config if keys == ("models", "fetched-krea") else {}
+        )
+        ctx.bot.generation_queue.add.reset_mock()
+        with (
+            patch(
+                "oneiro.discord.commands.resolve_loras",
+                new=AsyncMock(return_value=lora_result),
+            ),
+            patch(
+                "oneiro.discord.commands.create_dream_callbacks",
+                return_value=(MagicMock(), MagicMock(), MagicMock()),
+            ),
+        ):
+            await commands["dream"](ctx, "test prompt")
+        operator_request = ctx.bot.generation_queue.add.call_args.kwargs["request"]
+        assert operator_request["steps"] == 28
+        assert operator_request["guidance_scale"] == 4.5
+    elif checkpoint_kind == "cached_io_error":
+        ctx.bot.civitai_client.download_model_version.assert_not_awaited()
+        ctx.bot.civitai_client.get_safetensor_header.assert_not_awaited()
+        ctx.bot.civitai_client.cache.remove.assert_not_called()
+        failure = ctx.followup.send.await_args_list[-1]
+        assert "OSError: cached checkpoint read failed" in failure.kwargs["content"]
+    elif checkpoint_kind in {"quantized", "lora", "transport"}:
         ctx.bot.civitai_client.download_model_version.assert_not_awaited()
         ctx.bot.civitai_client.get_safetensor_header.assert_awaited_once()
     else:
-        if checkpoint_kind == "cached_malformed":
-            ctx.bot.civitai_client.download_model_version.assert_not_awaited()
-            ctx.bot.civitai_client.get_safetensor_header.assert_not_awaited()
-        else:
-            ctx.bot.civitai_client.download_model_version.assert_awaited_once()
-            ctx.bot.civitai_client.get_safetensor_header.assert_awaited_once()
+        ctx.bot.civitai_client.download_model_version.assert_awaited_once()
+        ctx.bot.civitai_client.get_safetensor_header.assert_awaited_once()
         assert not downloaded_path.exists()
-        ctx.bot.civitai_client.cache.remove.assert_called_once_with("ABC123")
+        assert ctx.bot.civitai_client.cache.remove.call_count == 1
+        ctx.bot.civitai_client.cache.remove.assert_called_with("ABC123")
 
 
 class TestValidateLoraWeight:

--- a/tests/test_civitai.py
+++ b/tests/test_civitai.py
@@ -1,6 +1,7 @@
 """Tests for CivitaiClient."""
 
 from pathlib import Path
+from unittest.mock import patch
 
 import httpx
 import pytest
@@ -12,6 +13,7 @@ from oneiro.civitai import (
     CivitaiCache,
     CivitaiClient,
     CivitaiError,
+    CivitaiHeaderError,
     CivitaiNotFoundError,
     CivitaiRateLimitError,
     Model,
@@ -201,7 +203,7 @@ class TestModelVersion:
         assert version.primary_file is not None
         assert version.primary_file.name == "first.bin"
 
-    def test_select_checkpoint_file_auto_prefers_diffusers_compatible_precision(self):
+    def test_checkpoint_files_auto_prefers_diffusers_compatible_precision(self):
         """Automatic checkpoint selection skips unsupported quantized files."""
         version = ModelVersion.from_dict(
             {
@@ -225,11 +227,11 @@ class TestModelVersion:
             }
         )
 
-        selected = version.select_checkpoint_file()
+        selected = version.checkpoint_files()[0]
 
         assert selected.id == 2
 
-    def test_select_checkpoint_file_honors_explicit_precision(self):
+    def test_checkpoint_files_honors_explicit_precision(self):
         """Explicit checkpoint precision overrides the automatic ranking."""
         version = ModelVersion.from_dict(
             {
@@ -253,11 +255,11 @@ class TestModelVersion:
             }
         )
 
-        selected = version.select_checkpoint_file("fp16")
+        selected = version.checkpoint_files("fp16")[0]
 
         assert selected.id == 2
 
-    def test_select_checkpoint_file_auto_prefers_policy_precision(self):
+    def test_checkpoint_files_auto_prefers_policy_precision(self):
         """Automatic checkpoint selection follows the resolved device policy dtype."""
         version = ModelVersion.from_dict(
             {
@@ -280,18 +282,82 @@ class TestModelVersion:
             }
         )
 
-        selected = version.select_checkpoint_file(preferred_precision="fp16")
+        selected = version.checkpoint_files("fp16")[0]
 
         assert selected.id == 2
 
-    def test_select_checkpoint_file_reports_unavailable_precision_as_civitai_error(self):
-        """Unavailable checkpoint precision is not reported as a URL parsing failure."""
+    def test_checkpoint_files_break_precision_ties_by_size(self):
+        """Larger files rank first when CivitAI precision metadata ties."""
+        version = ModelVersion.from_dict(
+            {
+                "id": 1,
+                "name": "Krea",
+                "files": [
+                    {
+                        "id": 1,
+                        "name": "small.safetensors",
+                        "sizeKB": 100,
+                        "downloadUrl": "http://x/small",
+                        "metadata": {"format": "SafeTensor", "fp": "bf16"},
+                    },
+                    {
+                        "id": 2,
+                        "name": "large.safetensors",
+                        "sizeKB": 200,
+                        "downloadUrl": "http://x/large",
+                        "metadata": {"format": "SafeTensor", "fp": "bf16"},
+                    },
+                ],
+            }
+        )
+
+        assert [file.id for file in version.checkpoint_files()] == [2, 1]
+
+    @pytest.mark.parametrize(
+        "metadata",
+        [
+            {"format": "SafeTensor"},
+            {"format": "SafeTensor", "fp": "fp8"},
+        ],
+    )
+    def test_checkpoint_files_keeps_weight_candidates_with_untrusted_precision_metadata(
+        self, metadata
+    ):
+        """Missing or incorrect precision metadata cannot exclude a weight checkpoint."""
+        version = ModelVersion.from_dict(
+            {
+                "id": 1,
+                "name": "Krea",
+                "files": [
+                    {
+                        "id": 1,
+                        "name": "untrusted-metadata.safetensors",
+                        "sizeKB": 100,
+                        "type": "Model",
+                        "downloadUrl": "http://x/untrusted",
+                        "metadata": metadata,
+                    },
+                    {
+                        "id": 2,
+                        "name": "bf16.safetensors",
+                        "sizeKB": 200,
+                        "type": "Model",
+                        "downloadUrl": "http://x/bf16",
+                        "metadata": {"format": "SafeTensor", "fp": "bf16"},
+                    },
+                ],
+            }
+        )
+
+        assert [file.id for file in version.checkpoint_files("bf16")] == [2, 1]
+
+    def test_checkpoint_files_treats_explicit_precision_as_a_preference(self):
+        """Unavailable metadata precision does not prevent later header validation."""
         version = ModelVersion.from_dict(SAMPLE_VERSION_RESPONSE)
 
-        with pytest.raises(CivitaiError, match="No fp32 SafeTensor checkpoint found"):
-            version.select_checkpoint_file("fp32")
+        assert version.checkpoint_files("fp32")[0].id == 11111
 
-    def test_select_checkpoint_file_never_returns_vae(self):
+    def test_checkpoint_files_never_returns_vae(self):
         """Floating-point VAE siblings are not mistaken for transformer checkpoints."""
         version = ModelVersion.from_dict(
             {
@@ -317,8 +383,15 @@ class TestModelVersion:
             }
         )
 
-        with pytest.raises(CivitaiError, match="No Diffusers-compatible"):
-            version.select_checkpoint_file()
+        assert version.checkpoint_files()[0].id == 1
+
+    def test_checkpoint_files_is_the_only_checkpoint_selection_api(self):
+        """Checkpoint selection exposes only ordered candidates and a precision preference."""
+        version = ModelVersion.from_dict(SAMPLE_VERSION_RESPONSE)
+
+        assert not hasattr(version, "select_checkpoint_file")
+        with pytest.raises(TypeError, match="unexpected keyword argument 'precision'"):
+            version.checkpoint_files(precision="fp16")
 
 
 class TestModel:
@@ -879,6 +952,32 @@ class TestCivitaiClientDownload:
             with pytest.raises(CivitaiError, match="Invalid SafeTensor tensor descriptor"):
                 await client.get_safetensor_header("https://civitai.com/api/download/models/1")
 
+    @pytest.mark.parametrize("error", [ValueError("integer too large"), RecursionError()])
+    @respx.mock
+    async def test_get_safetensor_header_normalizes_json_parser_errors(self, tmp_path, error):
+        """Pathological JSON remains a candidate-specific header failure."""
+        contents = (2).to_bytes(8, "little") + b"{}"
+        route = respx.get("https://civitai.com/api/download/models/1")
+        route.side_effect = [
+            httpx.Response(
+                206,
+                content=contents[:8],
+                headers={"Content-Range": "bytes 0-7/10"},
+            ),
+            httpx.Response(
+                206,
+                content=contents,
+                headers={"Content-Range": "bytes 0-9/10"},
+            ),
+        ]
+
+        async with CivitaiClient(cache_dir=tmp_path) as client:
+            with (
+                patch("oneiro.civitai.json.loads", side_effect=error),
+                pytest.raises(CivitaiHeaderError, match="Invalid SafeTensor header"),
+            ):
+                await client.get_safetensor_header("https://civitai.com/api/download/models/1")
+
     @respx.mock
     async def test_download_uses_cache(self, tmp_path):
         """download_file returns cached file if hash matches."""
@@ -955,7 +1054,7 @@ class TestCivitaiClientDownload:
                 ],
             }
         )
-        selected = version.select_checkpoint_file("fp16")
+        selected = version.checkpoint_files("fp16")[0]
 
         async with CivitaiClient(cache_dir=tmp_path, verify_hashes=False) as client:
             result = await client.download_model_version(version, model_file=selected)


### PR DESCRIPTION
Validate checkpoint candidates against their SafeTensor headers instead of relying on incomplete CivitAI precision metadata. Preserve fallback candidates and generation defaults for fetched Krea recipes.

Include bounded, ephemeral tracebacks for unexpected Discord failures so model-loading errors can be diagnosed without exceeding message limits.