### PR TITLE
fix(krea2): load published fast tokenizer

### DIFF
--- a/src/oneiro/pipelines/civitai_checkpoint.py
+++ b/src/oneiro/pipelines/civitai_checkpoint.py
@@ -901,6 +901,8 @@ class CivitaiCheckpointPipeline(LoraLoaderMixin, EmbeddingLoaderMixin, BasePipel
             if self._pipeline_config.pipeline_class == "Krea2Pipeline":
                 from diffusers import Krea2Pipeline
 
+                from oneiro.pipelines.krea2 import load_krea2_tokenizer
+
                 component_repo = self._krea2_component_repo(model_config)
                 transformer_subfolder = model_config.get("transformer_subfolder", "transformer")
                 transformer = self._load_krea2_transformer_from_single_file(
@@ -908,9 +910,11 @@ class CivitaiCheckpointPipeline(LoraLoaderMixin, EmbeddingLoaderMixin, BasePipel
                     component_repo,
                     transformer_subfolder,
                 )
+                tokenizer = load_krea2_tokenizer(component_repo)
                 return Krea2Pipeline.from_pretrained(
                     component_repo,
                     transformer=transformer,
+                    tokenizer=tokenizer,
                     torch_dtype=self.policy.dtype,
                 )
 

--- a/src/oneiro/pipelines/krea2.py
+++ b/src/oneiro/pipelines/krea2.py
@@ -10,6 +10,13 @@ from oneiro.pipelines.base import BasePipeline, GenerationResult
 from oneiro.pipelines.lora import LoraLoaderMixin
 
 
+def load_krea2_tokenizer(repo: str) -> Any:
+    """Load Krea's tokenizer from its published fast-tokenizer asset."""
+    from transformers import AutoTokenizer
+
+    return AutoTokenizer.from_pretrained(repo, subfolder="tokenizer", use_fast=True)
+
+
 class Krea2PipelineWrapper(LoraLoaderMixin, BasePipeline):
     """Wrapper for Krea 2 Raw and Turbo models."""
 
@@ -35,7 +42,12 @@ class Krea2PipelineWrapper(LoraLoaderMixin, BasePipeline):
             group_offload_use_stream=group_offload_use_stream,
             group_offload_num_blocks_per_group=group_offload_num_blocks_per_group,
         )
-        self.pipe = Krea2Pipeline.from_pretrained(repo, torch_dtype=self.policy.dtype)
+        tokenizer = load_krea2_tokenizer(repo)
+        self.pipe = Krea2Pipeline.from_pretrained(
+            repo,
+            tokenizer=tokenizer,
+            torch_dtype=self.policy.dtype,
+        )
 
         self.policy.apply_to_pipeline(self.pipe)
         print(f"Krea 2 loaded from {repo}")

--- a/tests/test_civitai_checkpoint.py
+++ b/tests/test_civitai_checkpoint.py
@@ -969,7 +969,12 @@ class TestCivitaiCheckpointPipelineLoad:
         checkpoint.write_bytes(b"dummy")
         mock_pipe = MagicMock()
         mock_transformer = MagicMock()
+        mock_tokenizer = MagicMock()
         mock_policy = DevicePolicy(device="cpu", dtype=torch.bfloat16, offload=OffloadMode.NEVER)
+
+        def load_tokenizer(repo):
+            mock_load_transformer.assert_called_once()
+            return mock_tokenizer
 
         with (
             patch.object(CivitaiCheckpointPipeline, "configure_scheduler"),
@@ -980,6 +985,11 @@ class TestCivitaiCheckpointPipelineLoad:
                 create=True,
                 return_value=mock_transformer,
             ) as mock_load_transformer,
+            patch(
+                "oneiro.pipelines.krea2.load_krea2_tokenizer",
+                create=True,
+                side_effect=load_tokenizer,
+            ) as mock_load_tokenizer,
             patch(
                 "oneiro.pipelines.civitai_checkpoint.get_diffusers_pipeline_class"
             ) as mock_get_class,
@@ -1001,9 +1011,11 @@ class TestCivitaiCheckpointPipelineLoad:
             "krea/Krea-2-Turbo",
             "transformer",
         )
+        mock_load_tokenizer.assert_called_once_with("krea/Krea-2-Turbo")
         mock_krea2_pipeline.from_pretrained.assert_called_once_with(
             "krea/Krea-2-Turbo",
             transformer=mock_transformer,
+            tokenizer=mock_tokenizer,
             torch_dtype=torch.bfloat16,
         )
 
@@ -1025,6 +1037,7 @@ class TestCivitaiCheckpointPipelineLoad:
         checkpoint = tmp_path / "krea2-raw.safetensors"
         checkpoint.write_bytes(b"dummy")
         mock_transformer = MagicMock()
+        mock_tokenizer = MagicMock()
         mock_policy = DevicePolicy(device="cpu", dtype=torch.bfloat16, offload=OffloadMode.NEVER)
 
         with (
@@ -1035,6 +1048,10 @@ class TestCivitaiCheckpointPipelineLoad:
                 "_load_krea2_transformer_from_single_file",
                 return_value=mock_transformer,
             ),
+            patch(
+                "oneiro.pipelines.krea2.load_krea2_tokenizer",
+                return_value=mock_tokenizer,
+            ) as mock_load_tokenizer,
             patch("diffusers.Krea2Pipeline") as mock_krea2_pipeline,
         ):
             mock_krea2_pipeline.from_pretrained.return_value = MagicMock()
@@ -1050,9 +1067,11 @@ class TestCivitaiCheckpointPipelineLoad:
         assert pipeline.pipeline_config is not None
         assert pipeline.pipeline_config.default_steps == expected_steps
         assert pipeline.pipeline_config.default_guidance_scale == expected_guidance
+        mock_load_tokenizer.assert_called_once_with(component_repo)
         mock_krea2_pipeline.from_pretrained.assert_called_once_with(
             component_repo,
             transformer=mock_transformer,
+            tokenizer=mock_tokenizer,
             torch_dtype=torch.bfloat16,
         )
 

--- a/tests/test_pipelines_base.py
+++ b/tests/test_pipelines_base.py
@@ -135,9 +135,10 @@ class TestPipelineManagerLoad:
 
     @patch("oneiro.pipelines.base.torch.set_num_interop_threads")
     @patch("oneiro.pipelines.base.torch.set_num_threads")
+    @patch("oneiro.pipelines.krea2.load_krea2_tokenizer")
     @patch("diffusers.Krea2Pipeline", create=True)
     async def test_resolves_named_local_lora_before_krea_load(
-        self, mock_krea2_pipeline, mock_threads, mock_interop, tmp_path
+        self, mock_krea2_pipeline, mock_tokenizer, mock_threads, mock_interop, tmp_path
     ):
         """Krea loading resolves local named LoRAs before synchronous model setup."""
         lora_path = tmp_path / "portrait.safetensors"

--- a/tests/test_pipelines_krea2.py
+++ b/tests/test_pipelines_krea2.py
@@ -7,9 +7,26 @@ import pytest
 import torch
 from PIL import Image
 
+import oneiro.pipelines.krea2 as krea2
 from oneiro.device import DevicePolicy, OffloadMode
 from oneiro.pipelines.krea2 import Krea2PipelineWrapper
 from oneiro.pipelines.lora import LoraConfig, LoraSource
+
+
+class TestLoadKrea2Tokenizer:
+    """Tests for load_krea2_tokenizer()."""
+
+    @patch("transformers.AutoTokenizer")
+    def test_loads_published_fast_tokenizer(self, mock_auto_tokenizer):
+        """Krea repositories load their published fast-tokenizer asset."""
+        tokenizer = krea2.load_krea2_tokenizer("krea/Krea-2-Turbo")
+
+        mock_auto_tokenizer.from_pretrained.assert_called_once_with(
+            "krea/Krea-2-Turbo",
+            subfolder="tokenizer",
+            use_fast=True,
+        )
+        assert tokenizer is mock_auto_tokenizer.from_pretrained.return_value
 
 
 class TestKrea2PipelineWrapperLoad:
@@ -18,13 +35,21 @@ class TestKrea2PipelineWrapperLoad:
     @patch("oneiro.pipelines.base.torch.set_num_interop_threads")
     @patch("oneiro.pipelines.base.torch.set_num_threads")
     @patch("diffusers.Krea2Pipeline", create=True)
-    def test_load_uses_turbo_repo_by_default(self, mock_krea2_pipeline, mock_threads, mock_interop):
-        """Load selects the official Turbo checkpoint when no repo is configured."""
-        pipeline = Krea2PipelineWrapper()
-        pipeline.load({"cpu_offload": False})
+    def test_load_uses_turbo_repo_and_fast_tokenizer_by_default(
+        self, mock_krea2_pipeline, mock_threads, mock_interop
+    ):
+        """Load selects the official Turbo checkpoint and its fast tokenizer by default."""
+        with patch(
+            "oneiro.pipelines.krea2.load_krea2_tokenizer",
+            create=True,
+        ) as mock_load_tokenizer:
+            pipeline = Krea2PipelineWrapper()
+            pipeline.load({"cpu_offload": False})
 
+        mock_load_tokenizer.assert_called_once_with("krea/Krea-2-Turbo")
         mock_krea2_pipeline.from_pretrained.assert_called_once_with(
             "krea/Krea-2-Turbo",
+            tokenizer=mock_load_tokenizer.return_value,
             torch_dtype=pipeline.policy.dtype,
         )
 


### PR DESCRIPTION
Krea repositories publish tokenizer.json without the vocab files required by the slow Qwen tokenizer, causing model loads to call open(None).

Load the fast tokenizer explicitly and pass it to both hosted and CivitAI pipeline assembly paths.