### PR TITLE
feat(krea2): support native FP8 checkpoints

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "Pillow>=10.0.0",
     "watchfiles>=0.21.0",
     "bitsandbytes>=0.42.0",
+    "comfy-kitchen>=0.2.26,<0.3.0",
     "peft>=0.7.0",
     "gguf>=0.6.0",
     "kernels>=0.3.0",

--- a/src/oneiro/pipelines/civitai_checkpoint.py
+++ b/src/oneiro/pipelines/civitai_checkpoint.py
@@ -5,6 +5,7 @@ diffusers' from_single_file() method. Automatically detects the appropriate
 pipeline class based on CivitAI's baseModel metadata.
 """
 
+import json
 import math
 import re
 from dataclasses import dataclass, replace
@@ -469,6 +470,7 @@ DEFAULT_FLUX2_KLEIN_4B_BASE_COMPONENT_REPO = "black-forest-labs/FLUX.2-klein-bas
 COMFY_DIFFUSION_MODEL_PREFIX = "model.diffusion_model."
 KREA2_DTYPE_PRECISIONS = {
     "BF16": "bf16",
+    "F8_E4M3": "fp8",
     "F16": "fp16",
     "F32": "fp32",
     "F64": "fp64",
@@ -490,6 +492,52 @@ DEFAULT_PIPELINE_CONFIG = PipelineConfig(
 )
 
 
+class _Krea2FP8Linear(torch.nn.Linear):
+    """Run Comfy FP8 weights with dynamically quantized activations."""
+
+    _oneiro_full_precision_mm = False
+
+    def forward(self, input: torch.Tensor) -> torch.Tensor:
+        """Apply the FP8 weight using its checkpoint scale."""
+        from comfy_kitchen.tensor import QuantizedTensor, TensorCoreFP8Layout
+
+        if self._oneiro_full_precision_mm:
+            return torch.nn.functional.linear(input, self.weight.dequantize(), self.bias)
+
+        quantized, params = TensorCoreFP8Layout.quantize(input)
+        quantized_input = QuantizedTensor(quantized, "TensorCoreFP8Layout", params)
+        return torch.nn.functional.linear(quantized_input, self.weight, self.bias)
+
+
+def _get_krea2_fp8_layers(metadata: dict[str, Any]) -> dict[str, bool]:
+    """Return Comfy FP8 layer names and their full-precision matmul flags."""
+    raw_metadata = metadata.get("_quantization_metadata")
+    if raw_metadata is None:
+        return {}
+    try:
+        quantization = json.loads(raw_metadata)
+    except (TypeError, ValueError) as error:
+        raise ValueError("Invalid Krea 2 quantization metadata") from error
+    layers = quantization.get("layers") if isinstance(quantization, dict) else None
+    if not isinstance(layers, dict) or not layers:
+        raise ValueError("Invalid Krea 2 quantization metadata")
+
+    result: dict[str, bool] = {}
+    for name, config in layers.items():
+        if (
+            not isinstance(name, str)
+            or not isinstance(config, dict)
+            or config.get("format") != "float8_e4m3fn"
+        ):
+            raise ValueError(
+                "Quantized Krea 2 single-file checkpoints are not supported by Diffusers"
+            )
+        result[name.removeprefix(COMFY_DIFFUSION_MODEL_PREFIX)] = bool(
+            config.get("full_precision_matrix_mult", False)
+        )
+    return result
+
+
 def get_krea2_checkpoint_precision_from_header(header: dict[str, Any]) -> str:
     """Validate a Krea SafeTensor header and return its dominant precision."""
     metadata = header.get("__metadata__", {}) or {}
@@ -500,14 +548,35 @@ def get_krea2_checkpoint_precision_from_header(header: dict[str, Any]) -> str:
         raise ValueError("Invalid SafeTensor header")
     source_keys = list(tensors)
     dtypes = {str(value.get("dtype", "")) for value in tensors.values()}
+    fp8_layers = _get_krea2_fp8_layers(metadata)
+    has_fp8 = "F8_E4M3" in dtypes
     if (
         not source_keys
-        or "_quantization_metadata" in metadata
-        or any(key.endswith(".weight_scale") for key in source_keys)
         or not dtypes.issubset(KREA2_DTYPE_PRECISIONS)
+        or (fp8_layers and not has_fp8)
+        or (any(key.endswith(".weight_scale") for key in source_keys) and not has_fp8)
     ):
         raise ValueError("Quantized Krea 2 single-file checkpoints are not supported by Diffusers")
-    normalized_keys = {key.removeprefix(COMFY_DIFFUSION_MODEL_PREFIX) for key in source_keys}
+    normalized_tensors = {
+        key.removeprefix(COMFY_DIFFUSION_MODEL_PREFIX): value for key, value in tensors.items()
+    }
+    normalized_keys = set(normalized_tensors)
+    fp8_keys = {key for key, value in normalized_tensors.items() if value.get("dtype") == "F8_E4M3"}
+    fp8_weights = {key for key in fp8_keys if key.endswith(".weight")}
+    scale_keys = {key for key in normalized_keys if key.endswith(".weight_scale")}
+    if fp8_keys != fp8_weights:
+        raise ValueError("Unexpected non-weight FP8 Krea 2 tensor")
+    if fp8_layers and fp8_weights != {f"{name}.weight" for name in fp8_layers}:
+        raise ValueError("Krea 2 FP8 metadata does not match checkpoint weights")
+    if scale_keys and {key.removesuffix("_scale") for key in scale_keys} != fp8_weights:
+        raise ValueError("Krea 2 FP8 checkpoint has missing or orphaned scales")
+    if fp8_layers and not scale_keys:
+        raise ValueError("Krea 2 FP8 checkpoint is missing weight scales")
+    if any(
+        normalized_tensors[key].get("dtype") != "F32" or normalized_tensors[key].get("shape") != []
+        for key in scale_keys
+    ):
+        raise ValueError("Krea 2 FP8 weight scales must be scalar FP32 tensors")
     if not KREA2_REQUIRED_TENSOR_KEYS.issubset(normalized_keys):
         raise ValueError("SafeTensor file does not contain Krea 2 transformer weights")
     element_counts = {
@@ -1010,9 +1079,10 @@ class CivitaiCheckpointPipeline(LoraLoaderMixin, EmbeddingLoaderMixin, BasePipel
         component_repo: str,
         transformer_subfolder: str,
     ) -> Any:
-        """Stream a floating-point Comfy Krea checkpoint into a Diffusers transformer."""
+        """Stream a Comfy Krea checkpoint into a Diffusers transformer."""
         from accelerate import init_empty_weights
         from accelerate.utils import set_module_tensor_to_device
+        from comfy_kitchen.tensor import QuantizedTensor, TensorCoreFP8Layout
         from diffusers import Krea2Transformer2DModel
         from safetensors import safe_open
 
@@ -1034,12 +1104,16 @@ class CivitaiCheckpointPipeline(LoraLoaderMixin, EmbeddingLoaderMixin, BasePipel
         }
         loaded_keys: set[str] = set()
         keep_in_fp32_modules = set(transformer._keep_in_fp32_modules)
+        fp8_loaded = False
 
         with safe_open(checkpoint_path, framework="pt", device="cpu") as checkpoint:
             source_keys = list(checkpoint.keys())
             _get_krea2_checkpoint_precision(checkpoint)
+            fp8_layers = _get_krea2_fp8_layers(checkpoint.metadata() or {})
 
             for source_key in source_keys:
+                if source_key.endswith(".weight_scale"):
+                    continue
                 tensor = checkpoint.get_tensor(source_key)
                 key, tensor = self._convert_krea2_checkpoint_tensor(source_key, tensor)
                 expected_shape = expected_shapes.get(key)
@@ -1050,6 +1124,38 @@ class CivitaiCheckpointPipeline(LoraLoaderMixin, EmbeddingLoaderMixin, BasePipel
                         f"Invalid shape for Krea 2 tensor {source_key}: "
                         f"expected {expected_shape}, got {tuple(tensor.shape)}"
                     )
+
+                if tensor.dtype == torch.float8_e4m3fn:
+                    if not source_key.endswith(".weight"):
+                        raise ValueError(f"Unexpected FP8 Krea 2 tensor: {source_key}")
+                    scale_key = f"{source_key.removesuffix('.weight')}.weight_scale"
+                    scale = (
+                        checkpoint.get_tensor(scale_key)
+                        if scale_key in source_keys
+                        else torch.ones((), dtype=torch.float32)
+                    )
+                    if scale.numel() != 1 or not torch.isfinite(scale).item() or scale.item() <= 0:
+                        raise ValueError(f"Invalid Krea 2 FP8 weight scale: {scale_key}")
+                    tensor = QuantizedTensor(
+                        tensor,
+                        "TensorCoreFP8Layout",
+                        TensorCoreFP8Layout.Params(
+                            scale=scale.float(),
+                            orig_dtype=self.policy.dtype,
+                            orig_shape=expected_shape,
+                        ),
+                    )
+                    module = transformer.get_submodule(key.removesuffix(".weight"))
+                    if not isinstance(module, torch.nn.Linear):
+                        raise ValueError(
+                            f"FP8 Krea 2 tensor does not target a linear layer: {source_key}"
+                        )
+                    module.__class__ = _Krea2FP8Linear
+                    layer_name = source_key.removeprefix(COMFY_DIFFUSION_MODEL_PREFIX).removesuffix(
+                        ".weight"
+                    )
+                    module._oneiro_full_precision_mm = fp8_layers.get(layer_name, False)
+                    fp8_loaded = True
 
                 set_module_tensor_to_device(
                     transformer,
@@ -1068,6 +1174,9 @@ class CivitaiCheckpointPipeline(LoraLoaderMixin, EmbeddingLoaderMixin, BasePipel
         if missing_keys:
             missing = ", ".join(sorted(missing_keys)[:3])
             raise ValueError(f"Krea 2 checkpoint is missing tensors: {missing}")
+
+        if fp8_loaded and self.policy.group_offload_use_stream:
+            self.policy = replace(self.policy, group_offload_use_stream=False)
 
         return transformer
 

--- a/tests/test_civitai_checkpoint.py
+++ b/tests/test_civitai_checkpoint.py
@@ -1075,22 +1075,21 @@ class TestCivitaiCheckpointPipelineLoad:
             torch_dtype=torch.bfloat16,
         )
 
-    def test_get_krea2_checkpoint_precision_rejects_quantized_tensor_header(self, tmp_path):
-        """Tensor dtypes override incorrect floating-point CivitAI metadata."""
+    def test_get_krea2_checkpoint_precision_reports_fp8_tensor_header(self, tmp_path):
+        """Tensor dtypes identify native FP8 Krea checkpoints."""
         from safetensors.torch import save_file
 
-        checkpoint = tmp_path / "mislabeled-bf16.safetensors"
+        checkpoint = tmp_path / "krea2-fp8.safetensors"
         save_file(
             {
-                "first.weight": torch.ones(2, dtype=torch.int8),
-                "last.linear.weight": torch.ones(2, dtype=torch.int8),
-                "blocks.0.attn.wq.weight": torch.ones(2, dtype=torch.int8),
+                "first.weight": torch.ones(2, dtype=torch.float8_e4m3fn),
+                "last.linear.weight": torch.ones(2, dtype=torch.float8_e4m3fn),
+                "blocks.0.attn.wq.weight": torch.ones(2, dtype=torch.float8_e4m3fn),
             },
             checkpoint,
         )
 
-        with pytest.raises(ValueError, match="Quantized Krea 2"):
-            get_krea2_checkpoint_precision(checkpoint)
+        assert get_krea2_checkpoint_precision(checkpoint) == "fp8"
 
     def test_get_krea2_checkpoint_precision_reads_tensor_header(self, tmp_path):
         """Displayed checkpoint precision comes from the SafeTensor header."""
@@ -1127,22 +1126,54 @@ class TestCivitaiCheckpointPipelineLoad:
 
         assert get_krea2_checkpoint_precision(checkpoint) == "bf16"
 
-    def test_get_krea2_checkpoint_precision_rejects_quantization_metadata(self, tmp_path):
-        """Quantization metadata is rejected even when every tensor claims BF16."""
+    def test_get_krea2_checkpoint_precision_reports_scaled_fp8_metadata(self, tmp_path):
+        """Comfy FP8 scales remain eligible for native quantized loading."""
         from safetensors.torch import save_file
 
-        checkpoint = tmp_path / "quantized-bf16.safetensors"
+        checkpoint = tmp_path / "krea2-scaled-fp8.safetensors"
         save_file(
             {
-                "first.weight": torch.ones(2, dtype=torch.bfloat16),
-                "last.linear.weight": torch.ones(2, dtype=torch.bfloat16),
-                "blocks.0.attn.wq.weight": torch.ones(2, dtype=torch.bfloat16),
+                "first.weight": torch.ones(2, dtype=torch.float8_e4m3fn),
+                "first.weight_scale": torch.tensor(0.5),
+                "last.linear.weight": torch.ones(2, dtype=torch.float8_e4m3fn),
+                "last.linear.weight_scale": torch.tensor(0.5),
+                "blocks.0.attn.wq.weight": torch.ones(2, dtype=torch.float8_e4m3fn),
+                "blocks.0.attn.wq.weight_scale": torch.tensor(0.5),
             },
             checkpoint,
-            metadata={"_quantization_metadata": "{}"},
+            metadata={
+                "_quantization_metadata": (
+                    '{"layers":{"first":{"format":"float8_e4m3fn"},'
+                    '"last.linear":{"format":"float8_e4m3fn"},'
+                    '"blocks.0.attn.wq":{"format":"float8_e4m3fn"}}}'
+                )
+            },
         )
 
-        with pytest.raises(ValueError, match="Quantized Krea 2"):
+        assert get_krea2_checkpoint_precision(checkpoint) == "fp8"
+
+    def test_get_krea2_checkpoint_precision_rejects_missing_fp8_scale(self, tmp_path):
+        """Scaled FP8 metadata requires a scale for every quantized weight."""
+        from safetensors.torch import save_file
+
+        checkpoint = tmp_path / "krea2-missing-fp8-scale.safetensors"
+        save_file(
+            {
+                "first.weight": torch.ones(2, dtype=torch.float8_e4m3fn),
+                "last.linear.weight": torch.ones(2, dtype=torch.float8_e4m3fn),
+                "blocks.0.attn.wq.weight": torch.ones(2, dtype=torch.float8_e4m3fn),
+            },
+            checkpoint,
+            metadata={
+                "_quantization_metadata": (
+                    '{"layers":{"first":{"format":"float8_e4m3fn"},'
+                    '"last.linear":{"format":"float8_e4m3fn"},'
+                    '"blocks.0.attn.wq":{"format":"float8_e4m3fn"}}}'
+                )
+            },
+        )
+
+        with pytest.raises(ValueError, match="scale"):
             get_krea2_checkpoint_precision(checkpoint)
 
     def test_load_krea2_transformer_uses_policy_dtype_and_keeps_norms_fp32(self, tmp_path):
@@ -1204,27 +1235,44 @@ class TestCivitaiCheckpointPipelineLoad:
         assert torch.equal(result.img_in.bias, source_bias.to(torch.bfloat16))
         assert torch.equal(result.final_layer.norm.weight, source_norm)
 
-    def test_load_krea2_transformer_rejects_quantized_checkpoint(self, tmp_path):
-        """Comfy quantization is rejected instead of being silently dequantized."""
+    def test_load_krea2_transformer_runs_scaled_fp8_without_dequantizing(self, tmp_path):
+        """Comfy FP8 weights retain quantized storage and apply their scale."""
         from safetensors.torch import save_file
 
-        fp8_dtype = getattr(torch, "float8_e4m3fn", None)
-        if fp8_dtype is None:
-            pytest.skip("torch build does not expose float8_e4m3fn")
-
         checkpoint = tmp_path / "krea2-fp8.safetensors"
+        source_weight = torch.tensor(
+            [[1.0, 2.0], [3.0, 4.0]],
+            dtype=torch.float8_e4m3fn,
+        )
         save_file(
             {
-                "first.weight": torch.zeros((4, 2), dtype=fp8_dtype),
-                "first.bias": torch.zeros(4),
+                "first.weight": source_weight,
+                "first.weight_scale": torch.tensor(0.5),
+                "last.linear.weight": source_weight.clone(),
+                "last.linear.weight_scale": torch.tensor(0.5),
+                "blocks.0.attn.wq.weight": source_weight.clone(),
+                "blocks.0.attn.wq.weight_scale": torch.tensor(0.5),
             },
             checkpoint,
-            metadata={"_quantization_metadata": "{}"},
+            metadata={
+                "_quantization_metadata": (
+                    '{"layers":{"first":{"format":"float8_e4m3fn"},'
+                    '"last.linear":{"format":"float8_e4m3fn",'
+                    '"full_precision_matrix_mult":true},'
+                    '"blocks.0.attn.wq":{"format":"float8_e4m3fn"}}}'
+                )
+            },
         )
         with torch.device("meta"):
             transformer = torch.nn.Module()
-            transformer.img_in = torch.nn.Linear(2, 4)
-        transformer._keep_in_fp32_modules = ["norm", "norm1", "norm2", "norm_q", "norm_k"]
+            transformer.img_in = torch.nn.Linear(2, 2, bias=False)
+            transformer.final_layer = torch.nn.Module()
+            transformer.final_layer.linear = torch.nn.Linear(2, 2, bias=False)
+            block = torch.nn.Module()
+            block.attn = torch.nn.Module()
+            block.attn.to_q = torch.nn.Linear(2, 2, bias=False)
+            transformer.transformer_blocks = torch.nn.ModuleList([block])
+        transformer._keep_in_fp32_modules = []
 
         pipeline = CivitaiCheckpointPipeline()
         pipeline.policy = DevicePolicy(
@@ -1233,17 +1281,31 @@ class TestCivitaiCheckpointPipelineLoad:
             offload=OffloadMode.NEVER,
         )
 
-        with (
-            patch("diffusers.Krea2Transformer2DModel") as mock_transformer_class,
-            pytest.raises(ValueError, match="Quantized Krea 2 single-file checkpoints"),
-        ):
+        with patch("diffusers.Krea2Transformer2DModel") as mock_transformer_class:
             mock_transformer_class.load_config.return_value = {"test": True}
             mock_transformer_class.from_config.return_value = transformer
-            pipeline._load_krea2_transformer_from_single_file(
+            result = pipeline._load_krea2_transformer_from_single_file(
                 checkpoint,
                 "krea/Krea-2-Turbo",
                 "transformer",
             )
+
+        assert result.img_in.weight._qdata.dtype == torch.float8_e4m3fn
+        from comfy_kitchen.tensor import TensorCoreFP8Layout
+
+        with patch.object(
+            TensorCoreFP8Layout,
+            "quantize",
+            wraps=TensorCoreFP8Layout.quantize,
+        ) as quantize:
+            input_tensor = torch.tensor([[[2.0, 1.0]]], dtype=torch.bfloat16)
+            output = result.img_in(input_tensor)
+            quantize.assert_called_once()
+            quantize.reset_mock()
+            result.final_layer.linear(input_tensor)
+            quantize.assert_not_called()
+        assert torch.equal(output, torch.tensor([[[2.0, 5.0]]], dtype=torch.bfloat16))
+        assert pipeline.policy.group_offload_use_stream is False
 
     def test_load_krea2_transformer_rejects_incomplete_checkpoint(self, tmp_path):
         """A truncated Krea checkpoint cannot leave meta parameters in the pipeline."""


### PR DESCRIPTION
CivitAI Krea releases increasingly publish Comfy FP8 checkpoints, but the loader rejected them and forced operators onto BF16 variants.

Preserve scaled FP8 weights with comfy-kitchen, quantize activations for native tensor-core execution, honor mixed-precision metadata, and disable streamed group offload for safe tensor movement.