### PR TITLE
fix(krea2): report checkpoint rejections

### DIFF
--- a/src/oneiro/discord/commands.py
+++ b/src/oneiro/discord/commands.py
@@ -821,8 +821,11 @@ def register_commands(bot: "OneiroBot") -> None:
                     version.name,
                     krea2_variant,
                 )
-                last_error = None
+                candidate_errors: list[str] = []
                 for candidate in candidates:
+                    candidate_label = (
+                        f"{candidate.name} ({candidate.fp or 'unknown'}, file {candidate.id})"
+                    )
                     cached = (
                         ctx.bot.civitai_client.cache.get(candidate.sha256)
                         if candidate.sha256
@@ -844,18 +847,19 @@ def register_commands(bot: "OneiroBot") -> None:
                                 candidate.download_url
                             )
                         except CivitaiHeaderError as error:
-                            last_error = error
+                            candidate_errors.append(f"{candidate_label}: {error}")
                             continue
                         except CivitaiError:
                             raise
                         try:
                             selected_precision = get_krea2_checkpoint_precision_from_header(header)
                         except ValueError as error:
-                            last_error = error
+                            candidate_errors.append(f"{candidate_label}: {error}")
                             continue
                     if precision != "auto" and selected_precision != precision:
-                        last_error = CivitaiError(
-                            f"Checkpoint contains {selected_precision}, not requested {precision}"
+                        candidate_errors.append(
+                            f"{candidate_label}: contains {selected_precision}, "
+                            f"not requested {precision}"
                         )
                         continue
                     if cached:
@@ -875,11 +879,12 @@ def register_commands(bot: "OneiroBot") -> None:
                             candidate,
                             candidate_path,
                         )
-                        last_error = error
+                        candidate_errors.append(f"{candidate_label}: {error}")
                         continue
                     if precision != "auto" and candidate_precision != precision:
-                        last_error = CivitaiError(
-                            f"Checkpoint contains {candidate_precision}, not requested {precision}"
+                        candidate_errors.append(
+                            f"{candidate_label}: contains {candidate_precision}, "
+                            f"not requested {precision}"
                         )
                         continue
                     selected_file = candidate
@@ -888,7 +893,9 @@ def register_commands(bot: "OneiroBot") -> None:
                     break
                 if selected_file is None:
                     raise CivitaiError(
-                        str(last_error) if last_error else "No valid Krea 2 checkpoint found"
+                        "; ".join(candidate_errors)
+                        if candidate_errors
+                        else "No valid Krea 2 checkpoint found"
                     )
             else:
                 downloaded_path = await ctx.bot.civitai_client.download_model_version(version)

--- a/src/oneiro/pipelines/civitai_checkpoint.py
+++ b/src/oneiro/pipelines/civitai_checkpoint.py
@@ -524,14 +524,10 @@ def _get_krea2_fp8_layers(metadata: dict[str, Any]) -> dict[str, bool]:
 
     result: dict[str, bool] = {}
     for name, config in layers.items():
-        if (
-            not isinstance(name, str)
-            or not isinstance(config, dict)
-            or config.get("format") != "float8_e4m3fn"
-        ):
-            raise ValueError(
-                "Quantized Krea 2 single-file checkpoints are not supported by Diffusers"
-            )
+        if not isinstance(name, str) or not isinstance(config, dict):
+            raise ValueError("Invalid Krea 2 quantization metadata")
+        if config.get("format") != "float8_e4m3fn":
+            raise ValueError(f"Unsupported Krea 2 quantization format: {config.get('format')}")
         result[name.removeprefix(COMFY_DIFFUSION_MODEL_PREFIX)] = bool(
             config.get("full_precision_matrix_mult", False)
         )
@@ -550,13 +546,17 @@ def get_krea2_checkpoint_precision_from_header(header: dict[str, Any]) -> str:
     dtypes = {str(value.get("dtype", "")) for value in tensors.values()}
     fp8_layers = _get_krea2_fp8_layers(metadata)
     has_fp8 = "F8_E4M3" in dtypes
-    if (
-        not source_keys
-        or not dtypes.issubset(KREA2_DTYPE_PRECISIONS)
-        or (fp8_layers and not has_fp8)
-        or (any(key.endswith(".weight_scale") for key in source_keys) and not has_fp8)
-    ):
-        raise ValueError("Quantized Krea 2 single-file checkpoints are not supported by Diffusers")
+    if not source_keys:
+        raise ValueError("Krea 2 checkpoint has no tensors")
+    unsupported_dtypes = dtypes - KREA2_DTYPE_PRECISIONS.keys()
+    if unsupported_dtypes:
+        raise ValueError(
+            f"Unsupported Krea 2 checkpoint dtypes: {', '.join(sorted(unsupported_dtypes))}"
+        )
+    if fp8_layers and not has_fp8:
+        raise ValueError("Krea 2 FP8 metadata has no FP8 weights")
+    if any(key.endswith(".weight_scale") for key in source_keys) and not has_fp8:
+        raise ValueError("Krea 2 FP8 scales have no FP8 weights")
     normalized_tensors = {
         key.removeprefix(COMFY_DIFFUSION_MODEL_PREFIX): value for key, value in tensors.items()
     }

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -711,6 +711,10 @@ async def test_fetch_krea2_validates_header_before_writing_config(
     elif checkpoint_kind in {"quantized", "lora", "transport"}:
         ctx.bot.civitai_client.download_model_version.assert_not_awaited()
         ctx.bot.civitai_client.get_safetensor_header.assert_awaited_once()
+        if checkpoint_kind == "quantized":
+            failure = ctx.followup.send.await_args_list[-1].args[0]
+            assert "krea.safetensors (bf16, file 3)" in failure
+            assert "I8" in failure
     else:
         ctx.bot.civitai_client.download_model_version.assert_awaited_once()
         ctx.bot.civitai_client.get_safetensor_header.assert_awaited_once()


### PR DESCRIPTION
`/fetch` tried each Krea checkpoint candidate but surfaced only the final failure, masking why an earlier FP8 file was skipped.

Include file identity, declared precision, unsupported dtypes, and quantization format for every rejected candidate so production failures identify the exact header mismatch without downloading model weights.