### PR TITLE
fix(krea2): attach full rejection details

### DIFF
--- a/src/oneiro/discord/commands.py
+++ b/src/oneiro/discord/commands.py
@@ -1082,7 +1082,9 @@ def register_commands(bot: "OneiroBot") -> None:
         except ValueError as e:
             await ctx.followup.send(f"❌ Invalid URL: {e}", ephemeral=True)
         except CivitaiError as e:
-            await ctx.followup.send(f"❌ Civitai error: {e}", ephemeral=True)
+            await ctx.followup.send(
+                **format_exception_response("❌ Civitai error", e), ephemeral=True
+            )
         except Exception as e:
             await ctx.followup.send(
                 **format_exception_response("❌ Failed to fetch", e), ephemeral=True

--- a/src/oneiro/pipelines/civitai_checkpoint.py
+++ b/src/oneiro/pipelines/civitai_checkpoint.py
@@ -548,11 +548,13 @@ def get_krea2_checkpoint_precision_from_header(header: dict[str, Any]) -> str:
     has_fp8 = "F8_E4M3" in dtypes
     if not source_keys:
         raise ValueError("Krea 2 checkpoint has no tensors")
-    unsupported_dtypes = dtypes - KREA2_DTYPE_PRECISIONS.keys()
-    if unsupported_dtypes:
-        raise ValueError(
-            f"Unsupported Krea 2 checkpoint dtypes: {', '.join(sorted(unsupported_dtypes))}"
-        )
+    unsupported_tensors = [
+        f"{key} ({value.get('dtype')} {value.get('shape')})"
+        for key, value in sorted(tensors.items())
+        if value.get("dtype") not in KREA2_DTYPE_PRECISIONS
+    ]
+    if unsupported_tensors:
+        raise ValueError(f"Unsupported Krea 2 checkpoint tensors: {', '.join(unsupported_tensors)}")
     if fp8_layers and not has_fp8:
         raise ValueError("Krea 2 FP8 metadata has no FP8 weights")
     if any(key.endswith(".weight_scale") for key in source_keys) and not has_fp8:

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -275,6 +275,44 @@ async def test_fetch_error_includes_traceback():
     assert call.kwargs.keys() == {"content", "ephemeral"}
 
 
+async def test_fetch_long_civitai_error_attaches_full_details():
+    """Expected Civitai failures preserve diagnostics beyond Discord's limit."""
+    commands = _register_test_commands()
+    error = CivitaiError("x" * 2500)
+    ctx = MagicMock()
+    ctx.defer = AsyncMock()
+    ctx.followup.send = AsyncMock(return_value=MagicMock())
+    ctx.bot.config.state_path = "state.toml"
+    ctx.bot.civitai_client.get_model = AsyncMock(side_effect=error)
+
+    await commands["fetch"](ctx, "https://civitai.com/models/1")
+
+    call = ctx.followup.send.await_args_list[-1]
+    assert call.kwargs["content"].startswith("❌ Civitai error")
+    assert len(call.kwargs["content"]) <= 2000
+    assert call.kwargs["file"].filename == "traceback.txt"
+    assert str(error) in call.kwargs["file"].fp.getvalue().decode()
+
+
+async def test_fetch_civitai_error_includes_traceback():
+    """Expected Civitai failures include their traceback for diagnosis."""
+    commands = _register_test_commands()
+    error = CivitaiError("checkpoint rejected")
+    ctx = MagicMock()
+    ctx.defer = AsyncMock()
+    ctx.followup.send = AsyncMock(return_value=MagicMock())
+    ctx.bot.config.state_path = "state.toml"
+    ctx.bot.civitai_client.get_model = AsyncMock(side_effect=error)
+
+    await commands["fetch"](ctx, "https://civitai.com/models/1")
+
+    call = ctx.followup.send.await_args_list[-1]
+    assert call.kwargs["content"].startswith("❌ Civitai error")
+    assert "Traceback (most recent call last)" in call.kwargs["content"]
+    assert "CivitaiError: checkpoint rejected" in call.kwargs["content"]
+    assert call.kwargs.keys() == {"content", "ephemeral"}
+
+
 async def test_image_read_error_includes_traceback():
     """Unexpected image read failures include their traceback in the response."""
     commands = _register_test_commands()
@@ -712,7 +750,7 @@ async def test_fetch_krea2_validates_header_before_writing_config(
         ctx.bot.civitai_client.download_model_version.assert_not_awaited()
         ctx.bot.civitai_client.get_safetensor_header.assert_awaited_once()
         if checkpoint_kind == "quantized":
-            failure = ctx.followup.send.await_args_list[-1].args[0]
+            failure = ctx.followup.send.await_args_list[-1].kwargs["content"]
             assert "krea.safetensors (bf16, file 3)" in failure
             assert "I8" in failure
     else:

--- a/tests/test_civitai_checkpoint.py
+++ b/tests/test_civitai_checkpoint.py
@@ -16,6 +16,7 @@ from oneiro.pipelines.civitai_checkpoint import (
     PipelineConfig,
     get_diffusers_pipeline_class,
     get_krea2_checkpoint_precision,
+    get_krea2_checkpoint_precision_from_header,
     get_pipeline_config_for_base_model,
 )
 from oneiro.pipelines.lora import LoraConfig, LoraSource
@@ -1090,6 +1091,21 @@ class TestCivitaiCheckpointPipelineLoad:
         )
 
         assert get_krea2_checkpoint_precision(checkpoint) == "fp8"
+
+    def test_get_krea2_checkpoint_precision_reports_unsupported_tensor_names(self):
+        """Unsupported quantized tensors identify their key, dtype, and shape."""
+        header = {
+            "first.weight": {"dtype": "F8_E4M3", "shape": [2, 2]},
+            "last.linear.weight": {"dtype": "F8_E4M3", "shape": [2, 2]},
+            "blocks.0.attn.wq.weight": {"dtype": "F8_E4M3", "shape": [2, 2]},
+            "blocks.0.attn.wq.weight_scale": {"dtype": "U8", "shape": [2, 1]},
+        }
+
+        with pytest.raises(
+            ValueError,
+            match=r"blocks\.0\.attn\.wq\.weight_scale \(U8 \[2, 1\]\)",
+        ):
+            get_krea2_checkpoint_precision_from_header(header)
 
     def test_get_krea2_checkpoint_precision_reads_tensor_header(self, tmp_path):
         """Displayed checkpoint precision comes from the SafeTensor header."""


### PR DESCRIPTION
Quantized checkpoints can produce candidate diagnostics longer than Discord's message limit, hiding the tensor information needed to identify their format.

Include unsupported tensor names, dtypes, and shapes, and attach the full sanitized error whenever the response exceeds the inline limit.