### PR TITLE
fix(krea2): load per-layer FP8 metadata

### DIFF
--- a/src/oneiro/discord/commands.py
+++ b/src/oneiro/discord/commands.py
@@ -619,7 +619,12 @@ def register_commands(bot: "OneiroBot") -> None:
             loading_msg = await ctx.followup.send(f"⏳ Loading model `{model}`...")
             try:
                 await ctx.bot.pipeline_manager.load_model(model)
-            except (CivitaiError, ValueError) as e:
+            except CivitaiError as e:
+                await ctx.followup.send(
+                    **format_exception_response("❌ Failed to load model", e), ephemeral=True
+                )
+                return
+            except ValueError as e:
                 await ctx.followup.send(f"❌ Failed to load model: {e}", ephemeral=True)
                 return
 

--- a/src/oneiro/pipelines/civitai_checkpoint.py
+++ b/src/oneiro/pipelines/civitai_checkpoint.py
@@ -528,9 +528,35 @@ def _get_krea2_fp8_layers(metadata: dict[str, Any]) -> dict[str, bool]:
             raise ValueError("Invalid Krea 2 quantization metadata")
         if config.get("format") != "float8_e4m3fn":
             raise ValueError(f"Unsupported Krea 2 quantization format: {config.get('format')}")
-        result[name.removeprefix(COMFY_DIFFUSION_MODEL_PREFIX)] = bool(
-            config.get("full_precision_matrix_mult", False)
-        )
+        full_precision = config.get("full_precision_matrix_mult", False)
+        if not isinstance(full_precision, bool):
+            raise ValueError("Krea 2 full_precision_matrix_mult must be a boolean")
+        result[name.removeprefix(COMFY_DIFFUSION_MODEL_PREFIX)] = full_precision
+    return result
+
+
+def _get_krea2_comfy_quant_layers(checkpoint: Any) -> dict[str, bool]:
+    """Read per-layer Comfy quantization descriptors from a checkpoint."""
+    result: dict[str, bool] = {}
+    for key in checkpoint.keys():
+        if not key.endswith(".comfy_quant"):
+            continue
+        descriptor = checkpoint.get_tensor(key)
+        if descriptor.dtype != torch.uint8 or descriptor.ndim != 1 or descriptor.numel() > 4096:
+            raise ValueError(f"Invalid Krea 2 quantization descriptor: {key}")
+        try:
+            config = json.loads(bytes(descriptor.tolist()).decode())
+        except (UnicodeDecodeError, ValueError) as error:
+            raise ValueError(f"Invalid Krea 2 quantization descriptor: {key}") from error
+        if not isinstance(config, dict):
+            raise ValueError(f"Invalid Krea 2 quantization descriptor: {key}")
+        if config.get("format") != "float8_e4m3fn":
+            raise ValueError(f"Unsupported Krea 2 quantization format: {config.get('format')}")
+        layer = key.removeprefix(COMFY_DIFFUSION_MODEL_PREFIX).removesuffix(".comfy_quant")
+        full_precision = config.get("full_precision_matrix_mult", False)
+        if not isinstance(full_precision, bool):
+            raise ValueError("Krea 2 full_precision_matrix_mult must be a boolean")
+        result[layer] = full_precision
     return result
 
 
@@ -552,6 +578,7 @@ def get_krea2_checkpoint_precision_from_header(header: dict[str, Any]) -> str:
         f"{key} ({value.get('dtype')} {value.get('shape')})"
         for key, value in sorted(tensors.items())
         if value.get("dtype") not in KREA2_DTYPE_PRECISIONS
+        and not (value.get("dtype") == "U8" and key.endswith(".comfy_quant"))
     ]
     if unsupported_tensors:
         raise ValueError(f"Unsupported Krea 2 checkpoint tensors: {', '.join(unsupported_tensors)}")
@@ -566,10 +593,26 @@ def get_krea2_checkpoint_precision_from_header(header: dict[str, Any]) -> str:
     fp8_keys = {key for key, value in normalized_tensors.items() if value.get("dtype") == "F8_E4M3"}
     fp8_weights = {key for key in fp8_keys if key.endswith(".weight")}
     scale_keys = {key for key in normalized_keys if key.endswith(".weight_scale")}
+    comfy_quant_keys = {key for key in normalized_keys if key.endswith(".comfy_quant")}
     if fp8_keys != fp8_weights:
         raise ValueError("Unexpected non-weight FP8 Krea 2 tensor")
     if fp8_layers and fp8_weights != {f"{name}.weight" for name in fp8_layers}:
         raise ValueError("Krea 2 FP8 metadata does not match checkpoint weights")
+    if (
+        comfy_quant_keys
+        and {f"{key.removesuffix('.comfy_quant')}.weight" for key in comfy_quant_keys}
+        != fp8_weights
+    ):
+        raise ValueError("Krea 2 Comfy quantization descriptors do not match FP8 weights")
+    if any(normalized_tensors[key].get("dtype") != "U8" for key in comfy_quant_keys):
+        raise ValueError("Krea 2 Comfy quantization descriptors must be U8 tensors")
+    if any(
+        normalized_tensors[key].get("shape") in (None, [])
+        or len(normalized_tensors[key]["shape"]) != 1
+        or normalized_tensors[key]["shape"][0] > 4096
+        for key in comfy_quant_keys
+    ):
+        raise ValueError("Invalid Krea 2 Comfy quantization descriptor shape")
     if scale_keys and {key.removesuffix("_scale") for key in scale_keys} != fp8_weights:
         raise ValueError("Krea 2 FP8 checkpoint has missing or orphaned scales")
     if fp8_layers and not scale_keys:
@@ -613,7 +656,15 @@ def get_krea2_checkpoint_precision(checkpoint_path: Path) -> str:
     from safetensors import safe_open
 
     with safe_open(checkpoint_path, framework="pt", device="cpu") as checkpoint:
-        return _get_krea2_checkpoint_precision(checkpoint)
+        precision = _get_krea2_checkpoint_precision(checkpoint)
+        metadata_layers = _get_krea2_fp8_layers(checkpoint.metadata() or {})
+        descriptor_layers = _get_krea2_comfy_quant_layers(checkpoint)
+        if any(
+            layer in metadata_layers and metadata_layers[layer] != full_precision
+            for layer, full_precision in descriptor_layers.items()
+        ):
+            raise ValueError("Conflicting Krea 2 quantization metadata")
+        return precision
 
 
 def get_krea2_generation_defaults(component_repo: str) -> tuple[int, float]:
@@ -1112,9 +1163,14 @@ class CivitaiCheckpointPipeline(LoraLoaderMixin, EmbeddingLoaderMixin, BasePipel
             source_keys = list(checkpoint.keys())
             _get_krea2_checkpoint_precision(checkpoint)
             fp8_layers = _get_krea2_fp8_layers(checkpoint.metadata() or {})
+            comfy_quant_layers = _get_krea2_comfy_quant_layers(checkpoint)
+            for layer, full_precision in comfy_quant_layers.items():
+                if layer in fp8_layers and fp8_layers[layer] != full_precision:
+                    raise ValueError(f"Conflicting Krea 2 quantization metadata: {layer}")
+                fp8_layers[layer] = full_precision
 
             for source_key in source_keys:
-                if source_key.endswith(".weight_scale"):
+                if source_key.endswith((".weight_scale", ".comfy_quant")):
                     continue
                 tensor = checkpoint.get_tensor(source_key)
                 key, tensor = self._convert_krea2_checkpoint_tensor(source_key, tensor)

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -213,10 +213,7 @@ async def test_model_error_includes_traceback_and_attaches_full_trace_when_trunc
     assert str(error) in call.kwargs["file"].fp.getvalue().decode()
 
 
-@pytest.mark.parametrize(
-    "error",
-    [CivitaiError("checkpoint download failed"), ValueError("invalid model configuration")],
-)
+@pytest.mark.parametrize("error", [ValueError("invalid model configuration")])
 async def test_model_expected_error_is_concise_and_ephemeral(error):
     """Expected model failures omit traceback details and attachments."""
     commands = _register_test_commands()
@@ -232,6 +229,26 @@ async def test_model_expected_error_is_concise_and_ephemeral(error):
     call = ctx.followup.send.await_args_list[-1]
     assert call.args == (f"❌ Failed to load model: {error}",)
     assert call.kwargs == {"ephemeral": True}
+
+
+async def test_model_civitai_error_includes_traceback():
+    """Civitai model-load failures include their traceback for diagnosis."""
+    commands = _register_test_commands()
+    error = CivitaiError("checkpoint download failed")
+    ctx = MagicMock()
+    ctx.defer = AsyncMock()
+    ctx.followup.send = AsyncMock(return_value=MagicMock())
+    ctx.bot.config.get.return_value = {"type": "test"}
+    ctx.bot.pipeline_manager.current_model = "working"
+    ctx.bot.pipeline_manager.load_model = AsyncMock(side_effect=error)
+
+    await commands["model"](ctx, "broken")
+
+    call = ctx.followup.send.await_args_list[-1]
+    assert call.kwargs["content"].startswith("❌ Failed to load model")
+    assert "Traceback (most recent call last)" in call.kwargs["content"]
+    assert "CivitaiError: checkpoint download failed" in call.kwargs["content"]
+    assert call.kwargs.keys() == {"content", "ephemeral"}
 
 
 async def test_model_post_load_value_error_includes_traceback():

--- a/tests/test_civitai_checkpoint.py
+++ b/tests/test_civitai_checkpoint.py
@@ -1107,6 +1107,68 @@ class TestCivitaiCheckpointPipelineLoad:
         ):
             get_krea2_checkpoint_precision_from_header(header)
 
+    def test_get_krea2_checkpoint_precision_accepts_comfy_quant_fp8_descriptors(self):
+        """Per-layer Comfy descriptors are valid auxiliaries for FP8 weights."""
+        header = {
+            "first.weight": {"dtype": "F8_E4M3", "shape": [2, 2]},
+            "first.comfy_quant": {"dtype": "U8", "shape": [27]},
+            "last.linear.weight": {"dtype": "F8_E4M3", "shape": [2, 2]},
+            "last.linear.comfy_quant": {"dtype": "U8", "shape": [27]},
+            "blocks.0.attn.wq.weight": {"dtype": "F8_E4M3", "shape": [2, 2]},
+            "blocks.0.attn.wq.comfy_quant": {"dtype": "U8", "shape": [27]},
+        }
+
+        assert get_krea2_checkpoint_precision_from_header(header) == "fp8"
+
+    def test_get_krea2_checkpoint_precision_rejects_non_u8_comfy_descriptor(self):
+        """Comfy quantization descriptors must use their serialized U8 representation."""
+        header = {
+            "first.weight": {"dtype": "F8_E4M3", "shape": [2, 2]},
+            "first.comfy_quant": {"dtype": "F32", "shape": [27]},
+            "last.linear.weight": {"dtype": "F8_E4M3", "shape": [2, 2]},
+            "last.linear.comfy_quant": {"dtype": "F32", "shape": [27]},
+            "blocks.0.attn.wq.weight": {"dtype": "F8_E4M3", "shape": [2, 2]},
+            "blocks.0.attn.wq.comfy_quant": {"dtype": "F32", "shape": [27]},
+        }
+
+        with pytest.raises(ValueError, match="descriptors must be U8"):
+            get_krea2_checkpoint_precision_from_header(header)
+
+    @pytest.mark.parametrize(
+        ("payload", "error"),
+        [
+            (b"not json", "Invalid Krea 2 quantization descriptor"),
+            (b'{"format": "mxfp8"}', "Unsupported Krea 2 quantization format: mxfp8"),
+            (
+                b'{"format": "float8_e4m3fn", "full_precision_matrix_mult": "false"}',
+                "full_precision_matrix_mult must be a boolean",
+            ),
+        ],
+    )
+    def test_get_krea2_checkpoint_precision_validates_comfy_descriptor_payload(
+        self, tmp_path, payload, error
+    ):
+        """Downloaded FP8 candidates validate descriptor JSON before selection."""
+        from safetensors.torch import save_file
+
+        checkpoint = tmp_path / "krea2-comfy-quant.safetensors"
+        weight = torch.ones((2, 2), dtype=torch.float8_e4m3fn)
+        descriptor = torch.tensor(list(payload), dtype=torch.uint8)
+        save_file(
+            {
+                "first.weight": weight,
+                "first.comfy_quant": descriptor,
+                "last.linear.weight": weight.clone(),
+                "last.linear.comfy_quant": descriptor.clone(),
+                "blocks.0.attn.wq.weight": weight.clone(),
+                "blocks.0.attn.wq.comfy_quant": descriptor.clone(),
+            },
+            checkpoint,
+        )
+
+        with pytest.raises(ValueError, match=error):
+            get_krea2_checkpoint_precision(checkpoint)
+
     def test_get_krea2_checkpoint_precision_reads_tensor_header(self, tmp_path):
         """Displayed checkpoint precision comes from the SafeTensor header."""
         from safetensors.torch import save_file
@@ -1322,6 +1384,57 @@ class TestCivitaiCheckpointPipelineLoad:
             quantize.assert_not_called()
         assert torch.equal(output, torch.tensor([[[2.0, 5.0]]], dtype=torch.bfloat16))
         assert pipeline.policy.group_offload_use_stream is False
+
+    def test_load_krea2_transformer_runs_comfy_quant_fp8(self, tmp_path):
+        """Converted FP8 descriptors preserve native FP8 execution."""
+        from safetensors.torch import save_file
+
+        checkpoint = tmp_path / "krea2-comfy-quant-fp8.safetensors"
+        source_weight = torch.tensor(
+            [[1.0, 2.0], [3.0, 4.0]],
+            dtype=torch.float8_e4m3fn,
+        )
+        descriptor = torch.tensor(
+            list(b'{"format": "float8_e4m3fn"}'),
+            dtype=torch.uint8,
+        )
+        save_file(
+            {
+                "first.weight": source_weight,
+                "first.comfy_quant": descriptor,
+            },
+            checkpoint,
+        )
+        with torch.device("meta"):
+            transformer = torch.nn.Module()
+            transformer.img_in = torch.nn.Linear(2, 2, bias=False)
+        transformer._keep_in_fp32_modules = []
+
+        pipeline = CivitaiCheckpointPipeline()
+        pipeline.policy = DevicePolicy(
+            device="cpu",
+            dtype=torch.bfloat16,
+            offload=OffloadMode.NEVER,
+        )
+
+        with (
+            patch("diffusers.Krea2Transformer2DModel") as mock_transformer_class,
+            patch(
+                "oneiro.pipelines.civitai_checkpoint._get_krea2_checkpoint_precision",
+                return_value="fp8",
+            ),
+        ):
+            mock_transformer_class.load_config.return_value = {"test": True}
+            mock_transformer_class.from_config.return_value = transformer
+            result = pipeline._load_krea2_transformer_from_single_file(
+                checkpoint,
+                "krea/Krea-2-Turbo",
+                "transformer",
+            )
+
+        assert result.img_in.weight._qdata.dtype == torch.float8_e4m3fn
+        output = result.img_in(torch.tensor([[[2.0, 1.0]]], dtype=torch.bfloat16))
+        assert torch.equal(output, torch.tensor([[[4.0, 10.0]]], dtype=torch.bfloat16))
 
     def test_load_krea2_transformer_rejects_incomplete_checkpoint(self, tmp_path):
         """A truncated Krea checkpoint cannot leave meta parameters in the pipeline."""


### PR DESCRIPTION
Moody Krea V6 stores each FP8 layer's quantization metadata in a serialized U8 comfy_quant tensor instead of the global SafeTensor metadata used by earlier releases.

Validate and parse those descriptors before selecting the download, carry their mixed-precision flags into native FP8 loading, and keep unsupported quantization formats rejected. Include tracebacks for Civitai model-load errors.