### PR TITLE
fix(krea2): make FP8 weights offloadable

### DIFF
--- a/src/oneiro/pipelines/civitai_checkpoint.py
+++ b/src/oneiro/pipelines/civitai_checkpoint.py
@@ -496,17 +496,28 @@ class _Krea2FP8Linear(torch.nn.Linear):
     """Run Comfy FP8 weights with dynamically quantized activations."""
 
     _oneiro_full_precision_mm = False
+    _oneiro_weight_dtype: torch.dtype
+    _oneiro_weight_scale: torch.Tensor
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:
         """Apply the FP8 weight using its checkpoint scale."""
         from comfy_kitchen.tensor import QuantizedTensor, TensorCoreFP8Layout
 
+        weight = QuantizedTensor(
+            self.weight,
+            "TensorCoreFP8Layout",
+            TensorCoreFP8Layout.Params(
+                scale=self._oneiro_weight_scale,
+                orig_dtype=self._oneiro_weight_dtype,
+                orig_shape=tuple(self.weight.shape),
+            ),
+        )
         if self._oneiro_full_precision_mm:
-            return torch.nn.functional.linear(input, self.weight.dequantize(), self.bias)
+            return torch.nn.functional.linear(input, weight.dequantize(), self.bias)
 
         quantized, params = TensorCoreFP8Layout.quantize(input)
         quantized_input = QuantizedTensor(quantized, "TensorCoreFP8Layout", params)
-        return torch.nn.functional.linear(quantized_input, self.weight, self.bias)
+        return torch.nn.functional.linear(quantized_input, weight, self.bias)
 
 
 def _get_krea2_fp8_layers(metadata: dict[str, Any]) -> dict[str, bool]:
@@ -1135,7 +1146,6 @@ class CivitaiCheckpointPipeline(LoraLoaderMixin, EmbeddingLoaderMixin, BasePipel
         """Stream a Comfy Krea checkpoint into a Diffusers transformer."""
         from accelerate import init_empty_weights
         from accelerate.utils import set_module_tensor_to_device
-        from comfy_kitchen.tensor import QuantizedTensor, TensorCoreFP8Layout
         from diffusers import Krea2Transformer2DModel
         from safetensors import safe_open
 
@@ -1194,21 +1204,14 @@ class CivitaiCheckpointPipeline(LoraLoaderMixin, EmbeddingLoaderMixin, BasePipel
                     )
                     if scale.numel() != 1 or not torch.isfinite(scale).item() or scale.item() <= 0:
                         raise ValueError(f"Invalid Krea 2 FP8 weight scale: {scale_key}")
-                    tensor = QuantizedTensor(
-                        tensor,
-                        "TensorCoreFP8Layout",
-                        TensorCoreFP8Layout.Params(
-                            scale=scale.float(),
-                            orig_dtype=self.policy.dtype,
-                            orig_shape=expected_shape,
-                        ),
-                    )
                     module = transformer.get_submodule(key.removesuffix(".weight"))
                     if not isinstance(module, torch.nn.Linear):
                         raise ValueError(
                             f"FP8 Krea 2 tensor does not target a linear layer: {source_key}"
                         )
                     module.__class__ = _Krea2FP8Linear
+                    module.register_buffer("_oneiro_weight_scale", scale.float(), persistent=False)
+                    module._oneiro_weight_dtype = self.policy.dtype
                     layer_name = source_key.removeprefix(COMFY_DIFFUSION_MODEL_PREFIX).removesuffix(
                         ".weight"
                     )
@@ -1221,9 +1224,13 @@ class CivitaiCheckpointPipeline(LoraLoaderMixin, EmbeddingLoaderMixin, BasePipel
                     "cpu",
                     value=tensor,
                     dtype=(
-                        torch.float32
-                        if keep_in_fp32_modules.intersection(key.split("."))
-                        else self.policy.dtype
+                        tensor.dtype
+                        if tensor.dtype == torch.float8_e4m3fn
+                        else (
+                            torch.float32
+                            if keep_in_fp32_modules.intersection(key.split("."))
+                            else self.policy.dtype
+                        )
                     ),
                 )
                 loaded_keys.add(key)

--- a/tests/test_civitai_checkpoint.py
+++ b/tests/test_civitai_checkpoint.py
@@ -1313,8 +1313,8 @@ class TestCivitaiCheckpointPipelineLoad:
         assert torch.equal(result.img_in.bias, source_bias.to(torch.bfloat16))
         assert torch.equal(result.final_layer.norm.weight, source_norm)
 
-    def test_load_krea2_transformer_runs_scaled_fp8_without_dequantizing(self, tmp_path):
-        """Comfy FP8 weights retain quantized storage and apply their scale."""
+    def test_load_krea2_transformer_runs_scaled_fp8_with_offloadable_storage(self, tmp_path):
+        """FP8 storage and scales remain visible to module device transfers."""
         from safetensors.torch import save_file
 
         checkpoint = tmp_path / "krea2-fp8.safetensors"
@@ -1368,7 +1368,12 @@ class TestCivitaiCheckpointPipelineLoad:
                 "transformer",
             )
 
-        assert result.img_in.weight._qdata.dtype == torch.float8_e4m3fn
+        assert result.img_in.weight.dtype == torch.float8_e4m3fn
+        assert (
+            result.img_in._oneiro_weight_scale
+            is dict(result.img_in.named_buffers())["_oneiro_weight_scale"]
+        )
+        assert result.img_in._oneiro_weight_scale.item() == 0.5
         from comfy_kitchen.tensor import TensorCoreFP8Layout
 
         with patch.object(
@@ -1432,7 +1437,7 @@ class TestCivitaiCheckpointPipelineLoad:
                 "transformer",
             )
 
-        assert result.img_in.weight._qdata.dtype == torch.float8_e4m3fn
+        assert result.img_in.weight.dtype == torch.float8_e4m3fn
         output = result.img_in(torch.tensor([[[2.0, 1.0]]], dtype=torch.bfloat16))
         assert torch.equal(output, torch.tensor([[[4.0, 10.0]]], dtype=torch.bfloat16))
 


### PR DESCRIPTION
Diffusers group offloading moves tensor wrapper storage without moving comfy-kitchen internal quantized data and scale. This leaves FP8 weights on CPU while activations run on CUDA.

Store FP8 data as a native parameter and its scale as a module buffer, then construct the quantized view only for execution.